### PR TITLE
"Fix" timescale NaNs

### DIFF
--- a/Mixtape/ghmm.py
+++ b/Mixtape/ghmm.py
@@ -384,7 +384,7 @@ class GaussianFusionHMM(object):
             # retain only eigenvalues > 0. These are the ones that correspond
             # to implied timescales. Eigenvalues below zero are possible (the
             # detailed balance constraint guarentees that the eigenvalues are
-            # in -1 < l < 1, but not that they strictly positive). But
+            # in -1 < l <= 1, but not that they strictly positive). But
             # eigevalues below zero do not have a real interpretation as
             # "implied timescales" because they correspond to sort of
             # damped oscillatory decays.


### PR DESCRIPTION
The NaNs in the timescales are actually not a problem, so this is mostly a cosmetic fix. The "problem" is really that detailed balance guarantees that the eigenvalues of the transition matrix are `-1 < \lambda <= 1`. The eigenvalues which are greater than zero can be interpreted as relaxation timescales, but the same interpretation is not totally appropriate for the eigenvalues which are less than zero. They correspond to a kind of damped oscillatory behavior. Honestly, they are mostly noise. If you look at the models, they're usually like -0.001 or something.

A stronger constraint on the transition matrix than detailed balance which is _also_ strongly physically justified is that it be representable as `T = expm(-K \tau)` (where `expm` is the matrix exponential), which means that `T` is the discrete-time manifestation of a continuous-time first order master equation, `dp/dt = -K p`. If the dynamics of this continuous-time master equation satisfy detailed balance, then K has a single eigenvector with eigenvalue 0 and the remaining eigenvalues are positive, which means that the eigenvalues of `T = expm(-K \tau)` are all strictly positive.

Anyways, the pull request just filters out these negative eigenvalues from the timescale calculation.
