### PR TITLE
tICA API changes

### DIFF
--- a/test/test_tica.py
+++ b/test/test_tica.py
@@ -15,12 +15,12 @@ def test_1():
     ticar.train(prep_trajectory=np.copy(X))
     y1 = ticar.project(prep_trajectory=np.copy(X), which=[0, 1])
 
-    tica = tICA(n_components=2, offset=1)
-    y2 = tica.fit_transform(np.copy(X))
+    tica = tICA(n_components=2, lag_time=1)
+    y2 = tica.fit_transform([np.copy(X)])[0]
 
     # check all of the internals state of the two implementations
     np.testing.assert_array_almost_equal(ticar.corrs, tica._outer_0_to_T_lagged)
-    np.testing.assert_array_almost_equal(ticar.sum_t, tica._sum_0_to_TminusOffset)
+    np.testing.assert_array_almost_equal(ticar.sum_t, tica._sum_0_to_TminusTau)
     np.testing.assert_array_almost_equal(ticar.sum_t_dt, tica._sum_tau_to_T)
     np.testing.assert_array_almost_equal(ticar.sum_all, tica._sum_0_to_T)
 
@@ -39,7 +39,7 @@ def test_singular_1():
     X = np.random.randn(100, 2)
     X = np.hstack((X, X[:,0, np.newaxis]))
 
-    tica.fit(X)
+    tica.fit([X])
     assert tica.components_.dtype == np.float64
     assert tica.eigenvalues_.dtype == np.float64
 
@@ -51,12 +51,12 @@ def test_singular_2():
     X = np.random.randn(100, 2)
     X = np.hstack((X, np.zeros((100, 1))))
 
-    tica.fit(X)
+    tica.fit([X])
     assert tica.components_.dtype == np.float64
     assert tica.eigenvalues_.dtype == np.float64
 
 def test_shape():
-    model = tICA(n_components=3).fit(np.random.randn(100,10))
+    model = tICA(n_components=3).fit([np.random.randn(100,10)])
     eq(model.eigenvalues_.shape, (3,))
     eq(model.eigenvectors_.shape, (10, 3))
     eq(model.components_.shape, (3, 10))


### PR DESCRIPTION
1. Change the name of the hyperparameter `offset` to `lag_time`.
2. Change the signature of `fit()`, `transform()`, and `fit_transform()` to take lists of arrays, instead of a single array. The API of `partial_fit` is unchanged -- it still takes a single array.
