### PR TITLE
Featurizer docs

### DIFF
--- a/Mixtape/featurizer.py
+++ b/Mixtape/featurizer.py
@@ -148,6 +148,8 @@ class AtomPairsFeaturizer(Featurizer):
     """
 
     def __init__(self, pair_indices, periodic=False, exponent=1.):
+        # TODO: We might want to implement more error checking here. Or during
+        # featurize(). E.g. are the pair_indices supplied valid?
         self.pair_indices = pair_indices
         self.n_features = len(self.pair_indices)
         self.periodic = periodic
@@ -163,7 +165,7 @@ class DihedralFeaturizer(Featurizer):
 
     Parameters
     ----------
-    types : list
+    types : list of strings
         One or more of ['phi', 'psi', 'omega', 'chi1', 'chi2', 'chi3', 'chi4']
     sincos : bool
         Transform to sine and cosine (double the number of featurizers)


### PR DESCRIPTION
@kyleabeauchamp Is there a reason that `refence_traj` was an `__init__` arg for AtomPairsFeaturizer?
