### PR TITLE
Add pre_args

### DIFF
--- a/scripts/pbsipcluster
+++ b/scripts/pbsipcluster
@@ -39,7 +39,7 @@ parser.add_argument('-id', '--cluster-id',
                     help='Set the cluster ID to avoid collisions.')
 parser.add_argument('-pre', '--pre-args',
                     help='Arguments executed on remote hosts before ' +
-                         'ipengine start.')
+                         'ipengine start. Only used with the ssh launcher.')
 parser.add_argument('--launcher', choices=['ssh', 'mpi'], default='ssh',
                     help='launch the ipengines by ssh-ing to the nodes ' +
                     'or using the mpiexec launcher.\nNote that "ssh" '


### PR DESCRIPTION
Add `--pre-args` argument, which specifies commands to be executed on the remote host prior to starting ipengine.

For example, I am using Theano on a GPU cluster and I want to avoid having different processes compete for the same graph compilation directory (since the locking mechanism only allows one compilation at a time), so in my PBS script I have:

```
cd $PBS_O_WORKDIR
id=`uuidgen`
pre_args='export THEANO_FLAGS="$THEANO_FLAGS,compiledir_format=tmp`uuidgen`"'
/home/kearnes/git/mixtape/scripts/pbsipcluster --daemonize -id $id -pre "$pre_args"
```

Which sets the Theano compile directory to a unique folder for each ipengine process.
