### PR TITLE
Spread out ssh connections

### DIFF
--- a/scripts/pbsipcluster
+++ b/scripts/pbsipcluster
@@ -138,6 +138,7 @@ def main():
                 cluster_id=cluster_id, quiet=q)))
             engine.daemon = True
             engine.start()
+            time.sleep(1)  # spread out ssh connections
     elif ARGS.launcher == 'mpi':
         engine = threading.Thread(target=lambda: os.system(
             ('mpiexec -machinefile {nodefile} '


### PR DESCRIPTION
Making too many ssh connections at once on biox3 is causing `connection closed by remote host` errors and preventing several of the engines from initializing. Spreading out the connections seems to solve the problem.
