### PR TITLE
libdistance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: c
 
+branches:
+  only:
+    - master
+
 install:
   - source devtools/ci/install.sh
   - export PYTHONUNBUFFERED=true

--- a/Mixtape/libdistance/.gitignore
+++ b/Mixtape/libdistance/.gitignore
@@ -1,0 +1,1 @@
+libdistance.cpp

--- a/Mixtape/libdistance/libdistance.pyx
+++ b/Mixtape/libdistance/libdistance.pyx
@@ -1,0 +1,430 @@
+# cython: c_string_type=str, c_string_encoding=ascii
+from __future__ import print_function
+import numpy as np
+import mdtraj as md
+from libc.float cimport FLT_MAX
+from libc.string cimport strcmp
+from numpy cimport npy_intp
+
+__all__ = ['assign_nearest', 'pdist', 'dist']
+
+cdef VECTOR_METRICS = ("euclidean", "sqeuclidean", "cityblock", "chebyshev",
+                       "canberra", "braycurtis", "hamming", "jaccard",
+                       "cityblock")
+cdef const char* RMSD = "rmsd"
+
+#-----------------------------------------------------------------------------
+# extern
+#-----------------------------------------------------------------------------
+
+cdef extern from "assign.hpp":
+    double assign_nearest_double(const double* X, const double* Y,
+        const char* metric, const npy_intp* X_indices, npy_intp n_X,
+        npy_intp n_Y, npy_intp n_features, npy_intp n_X_indices,
+        npy_intp* assignments) nogil
+    double assign_nearest_float(const float* X, const float* Y,
+        const char* metric, const npy_intp* X_indices, npy_intp n_X,
+        npy_intp n_Y, npy_intp n_features, npy_intp n_X_indices,
+        npy_intp* assignments) nogil
+cdef extern from "pdist.hpp":
+    void pdist_double(const double* X, const char* metric, npy_intp n, npy_intp m,
+        double* out) nogil
+    void pdist_float(const float* X, const char* metric, npy_intp n, npy_intp m,
+        double* out) nogil
+    void pdist_double_X_indices(const double* X, const char* metric, npy_intp n,
+        npy_intp m, const npy_intp* X_indices, npy_intp n_X_indices,
+        double* out) nogil
+    void pdist_float_X_indices(const float* X, const char* metric, npy_intp n,
+        npy_intp m, const npy_intp* X_indices, npy_intp n_X_indices,
+        double* out) nogil
+cdef extern from "dist.hpp":
+    void dist_double(const double* X, const double* y, const char* metric,
+        npy_intp n, npy_intp m, double* out) nogil
+    void dist_float(const float* X, const float* y, const char* metric,
+        npy_intp n, npy_intp m, double* out) nogil
+    void dist_double_X_indices(const double* X, const double* y, const char* metric,
+        npy_intp n, npy_intp m, const npy_intp* X_indices, npy_intp n_X_indices,
+        double* out) nogil
+    void dist_float_X_indices(const float* X, const float* y, const char* metric,
+        npy_intp n, npy_intp m, const npy_intp* X_indices, npy_intp n_X_indices,
+        double* out) nogil
+cdef extern from "center.h":
+    void inplace_center_and_trace_atom_major(float* coords, float* traces,
+        const int n_frames, const int n_atoms) nogil
+cdef extern from "theobald_rmsd.h":
+    cdef extern float msd_atom_major(int nrealatoms, int npaddedatoms, float* a,
+        float* b, float G_a, float G_b, int computeRot, float rot[9]) nogil
+
+cdef extern from "math.h":
+    float sqrt(float x) nogil
+
+#-----------------------------------------------------------------------------
+# Public interface functions
+#-----------------------------------------------------------------------------
+
+
+def assign_nearest(X, Y, char* metric, npy_intp[::1] X_indices=None):
+    """assign_nearest(X, Y, metric, X_indices=None)
+
+    For each point in X, compute the index of the nearest element in Y.
+
+    Parameters
+    ----------
+    X : array, shape = (n_samples_X, n_features) or md.Trajectory
+        The data array
+    Y : array, shape = (n_samples_Y, n_features) or md.Trajectory
+        The array of cluster centers
+    metric : {"euclidean", "sqeuclidean", "cityblock", "chebyshev", "canberra",
+              "braycurtis", "hamming", "jaccard", "cityblock", "rmsd"}
+        The distance metric to use. metric = "rmsd" requires that both X
+        and cluster centers be of type md.Trajectory; other distance metrics
+        require that they be arrays.
+    X_indices : array of indices, or None
+        If supplied, only data points with index in X_indices will be
+        considered. `X_indices = None` is equivalent to
+        `X_indices = range(len(X))`
+
+    Returns
+    -------
+    assignments : array, shape=(len(X),), or shape=(len(X_indices),)
+        For each point in `X`, or `X[X_indices]`, the index of the nearest
+        point in `Y`.
+    inertia : double
+        The sum of the distance from each point in X[X_indices] to its assigned
+        point in `Y`.
+
+    See Also
+    --------
+    mdtraj.rmsd
+    """
+    if (isinstance(X, md.Trajectory) and isinstance(Y, md.Trajectory) and strcmp(metric, RMSD) == 0):
+        return _assign_nearest_rmsd(X, Y, X_indices)
+    else:
+        if not isinstance(X, np.ndarray) and isinstance(Y, np.ndarray):
+            raise TypeError()
+        if metric not in VECTOR_METRICS:
+            raise ValueError('metric must be one of %s' %
+                             ', '.join("'%s'" % s for s in VECTOR_METRICS))
+
+        if X.dtype == np.float64 and Y.dtype == np.float64:
+            return _assign_nearest_double(X, Y, metric, X_indices)
+        elif X.dtype == np.float32 and Y.dtype == np.float32:
+            return _assign_nearest_float(X, Y, metric, X_indices)
+        else:
+            raise TypeError('X and y must be both float32 or float64')
+
+
+def pdist(X, char* metric, npy_intp[::1] X_indices=None):
+    """pdist(X, metric, X_indices=None)
+
+    Pairwise distances between observations
+
+    Parameters
+    ----------
+    X : array, shape = (n_samples, n_features) or md.Trajectory
+        The data array
+    metric : {"euclidean", "sqeuclidean", "cityblock", "chebyshev", "canberra",
+              "braycurtis", "hamming", "jaccard", "cityblock", "rmsd"}
+        The distance metric to use. metric = "rmsd" requires that X be of type
+        md.Trajectory; other distance metrics require that it be a numpy array
+    X_indices : array of indices, or None
+        If supplied, only data points with index in X_indices will be considered.
+        `X_indices = None` is equivalent to `X_indices = range(len(X))`
+
+    Returns
+    -------
+    dist : ndarray, size=(len(X) choose 2,) or shape=(len(X_indices) choose 2,)
+        Returns a condensed distance matrix `dist`.  For
+        each :math:`i` and :math:`j` (where :math:`i<j<n`), the
+        metric ``dist(u=X[i], v=X[j])`` is computed and stored in entry ``ij``.
+
+    See Also
+    --------
+    mdtraj.rmsd
+    scipy.spatial.distance.pdist
+    scipy.spatial.distance.squareform
+    """
+    if (isinstance(X, md.Trajectory) and strcmp(metric, RMSD) == 0):
+        return _pdist_rmsd(X, X_indices)
+    else:
+        if not isinstance(X, np.ndarray):
+            raise TypeError()
+        if metric not in VECTOR_METRICS:
+            raise ValueError('metric must be one of %s' %
+                             ', '.join("'%s'" % s for s in VECTOR_METRICS))
+
+        if X.dtype == np.float64:
+            return _pdist_double(X, metric, X_indices)
+        elif X.dtype == np.float32:
+            return _pdist_float(X, metric, X_indices)
+        else:
+            raise TypeError('X must be float32 or float64')
+
+
+def dist(X, y, char* metric, npy_intp[::1] X_indices=None):
+    """dist(X, y, metric, X_indices=None)
+
+    Distance from one point to many points.
+
+    Parameters
+    ----------
+    X : array, shape = (n_samples, n_features) or md.Trajectory
+        A data array
+    y : array, shape = (n_features) or md.Trajectory of length 1
+        A single data point
+    metric : {"euclidean", "sqeuclidean", "cityblock", "chebyshev", "canberra",
+              "braycurtis", "hamming", "jaccard", "cityblock", "rmsd"}
+        The distance metric to use. metric = "rmsd" requires that both X
+        and cluster centers be of type md.Trajectory; other distance metrics
+        require that they be arrays.
+
+    Returns
+    -------
+    Y : ndarray, shape=(len(X),) or len(X_indices)
+        The distance from Y to each `X` or `X[X_indices]`.
+
+    See Also
+    --------
+    mdtraj.rmsd
+    scipy.spatial.distance.cdist
+    """
+    if (isinstance(X, md.Trajectory) and isinstance(y, md.Trajectory) and strcmp(metric, RMSD) == 0):
+        return _dist_rmsd(X, y, X_indices)
+    else:
+        if not isinstance(X, np.ndarray) and isinstance(y, np.ndarray):
+            raise TypeError()
+        if metric not in VECTOR_METRICS:
+            raise ValueError('metric must be one of %s' %
+                             ', '.join("'%s'" % s for s in VECTOR_METRICS))
+
+        if X.dtype == np.float64 and y.dtype == np.float64:
+            return _dist_double(X, y, metric, X_indices)
+        elif X.dtype == np.float32 and y.dtype == np.float32:
+            return _dist_float(X, y, metric, X_indices)
+        else:
+            raise TypeError('X and y must be both float32 or float64')
+
+
+#-----------------------------------------------------------------------------
+# Private implementation
+#-----------------------------------------------------------------------------
+
+cdef _assign_nearest_rmsd(X, Y, npy_intp[::1] X_indices=None):
+    cdef npy_intp i, ii, j
+    assert (X.xyz.ndim == 3) and (Y.xyz.ndim == 3) and \
+           (X.xyz.shape[2]) == 3 and (Y.xyz.shape[2] == 3)
+    if not (X.xyz.shape[1]  == Y.xyz.shape[1]):
+        raise ValueError("Input trajectories must have same number of atoms. "
+                         "found %d and %d." % (X.xyz.shape[1], Y.xyz.shape[1]))
+
+    cdef double inertia = 0
+    cdef float min_d, rmsd
+    cdef float[:, :, ::1] X_xyz = X.xyz
+    cdef float[:, :, ::1] Y_xyz = Y.xyz
+    cdef int n_atoms = X.xyz.shape[1]
+    cdef npy_intp length
+    cdef npy_intp X_length = X_xyz.shape[0]
+    cdef npy_intp Y_length = Y_xyz.shape[0]
+    cdef npy_intp[::1] assignments
+    cdef float X_trace
+    cdef float[::1] Y_trace = np.zeros(Y_length, dtype=np.float32)
+    inplace_center_and_trace_atom_major(&Y_xyz[0, 0, 0], &Y_trace[0], Y_length, n_atoms)
+
+    if X_indices is None:
+        length = X_length
+        assignments = np.zeros(length, dtype=np.intp)
+
+        for i in range(length):
+            inplace_center_and_trace_atom_major(&X_xyz[i, 0, 0], &X_trace, 1, n_atoms)
+            min_d = FLT_MAX;
+            for j in range(Y_length):
+                rmsd = sqrt(msd_atom_major(n_atoms, n_atoms, &X_xyz[i, 0, 0],
+                    &Y_xyz[j, 0, 0], X_trace, Y_trace[j], 0, NULL))
+                if rmsd < min_d:
+                    min_d = rmsd;
+                    assignments[i] = j;
+            inertia += min_d;
+    else:
+        length = X_indices.shape[0]
+        assignments = np.zeros(length, dtype=np.intp)
+
+        for i in range(length):
+            ii = X_indices[i]
+            inplace_center_and_trace_atom_major(&X_xyz[ii, 0, 0], &X_trace, 1, n_atoms)
+            min_d = FLT_MAX;
+            for j in range(Y_length):
+                rmsd = sqrt(msd_atom_major(n_atoms, n_atoms, &X_xyz[ii, 0, 0],
+                    &Y_xyz[j, 0, 0], X_trace, Y_trace[j], 0, NULL))
+                if rmsd < min_d:
+                    min_d = rmsd;
+                    assignments[i] = j;
+            inertia += min_d;
+
+    return np.array(assignments, copy=False), inertia
+
+
+cdef _assign_nearest_double(double[:, ::1] X, double[:, ::1] Y,
+                            char* metric, npy_intp[::1] X_indices=None):
+    cdef npy_intp[::1] assignments
+    cdef npy_intp length, n_features
+    n_features = X.shape[1]
+    assert n_features == Y.shape[1]
+    if X_indices is None:
+        length = X.shape[0]
+    else:
+        length = X_indices.shape[0]
+    assignments = np.zeros(length, dtype=np.intp)
+
+    cdef double inertia = assign_nearest_double(
+        &X[0, 0], &Y[0, 0], metric,
+        <npy_intp*> NULL if X_indices is None else &X_indices[0],
+        X.shape[0], Y.shape[0], n_features, length,
+        &assignments[0])
+    return np.array(assignments, copy=False), inertia
+
+
+cdef _assign_nearest_float(float[:, ::1] X, float[:, ::1] Y,
+                           char* metric, npy_intp[::1] X_indices=None):
+    cdef npy_intp[::1] assignments
+    cdef npy_intp length, n_features
+    n_features = X.shape[1]
+    assert n_features == Y.shape[1]
+    if X_indices is None:
+        length = X.shape[0]
+    else:
+        length = X_indices.shape[0]
+    assignments = np.zeros(length, dtype=np.intp)
+
+    cdef double inertia = assign_nearest_float(
+        &X[0, 0], &Y[0, 0], metric,
+        <npy_intp*> NULL if X_indices is None else &X_indices[0],
+        X.shape[0], Y.shape[0], n_features, length,
+        &assignments[0])
+    return np.array(assignments, copy=False), inertia
+
+
+cdef _pdist_rmsd(X, npy_intp[::1] X_indices=None):
+    cdef npy_intp i, j, k
+
+    cdef double[::1] out
+    cdef float[:, :, ::1] X_xyz = X.xyz
+    cdef float[::1] X_trace
+    cdef int n_atoms = X.xyz.shape[1]
+    cdef npy_intp X_length = X_xyz.shape[0]
+    cdef float Xi_trace, Xj_trace
+
+    if X_indices is None:
+        X_trace = np.zeros(X_xyz.shape[0], dtype=np.float32)
+        out = np.zeros(X_xyz.shape[0] * (X_xyz.shape[0] - 1) / 2, dtype=np.double)
+        inplace_center_and_trace_atom_major(&X_xyz[0, 0, 0],
+            &X_trace[0], X_xyz.shape[0], n_atoms)
+
+        k = 0
+        for i in range(X_xyz.shape[0]):
+            for j in range(i+1, X_xyz.shape[0]):
+                rmsd = sqrt(msd_atom_major(n_atoms, n_atoms, &X_xyz[i, 0, 0],
+                            &X_xyz[j, 0, 0], X_trace[i], X_trace[j], 0, NULL))
+                out[k] = rmsd
+                k += 1
+    else:
+        out = np.zeros(X_indices.shape[0] * (X_indices.shape[0] - 1) / 2, dtype=np.double)
+
+        k = 0
+        for i in range(X_indices.shape[0]):
+            inplace_center_and_trace_atom_major(&X_xyz[X_indices[i], 0, 0],
+                &Xi_trace, 1, n_atoms)
+            for j in range(i+1, X_indices.shape[0]):
+                inplace_center_and_trace_atom_major(&X_xyz[X_indices[j], 0, 0],
+                    &Xj_trace, 1, n_atoms)
+                rmsd = sqrt(msd_atom_major(n_atoms, n_atoms, &X_xyz[X_indices[i], 0, 0],
+                            &X_xyz[X_indices[j], 0, 0], Xi_trace, Xj_trace, 0, NULL))
+                out[k] = rmsd
+                k += 1
+
+    return np.array(out, copy=False)
+
+
+cdef _pdist_double(double[:, ::1] X, char* metric, npy_intp[::1] X_indices=None):
+    cdef double[::1] out
+    if X_indices is None:
+        out = np.zeros(X.shape[0] * (X.shape[0] - 1) / 2, dtype=np.double)
+        pdist_double(&X[0,0], metric, X.shape[0], X.shape[1], &out[0])
+    else:
+        out = np.zeros(X_indices.shape[0] * (X_indices.shape[0] - 1) / 2, dtype=np.double)
+        pdist_double_X_indices(&X[0, 0], metric, X.shape[0], X.shape[1],
+            &X_indices[0], X_indices.shape[0], &out[0])
+
+    return np.array(out, copy=False)
+
+
+cdef _pdist_float(float[:, ::1] X, char* metric, npy_intp[::1] X_indices=None):
+    cdef double[::1] out
+    if X_indices is None:
+        out = np.zeros(X.shape[0] * (X.shape[0] - 1) / 2, dtype=np.double)
+        pdist_float(&X[0,0], metric, X.shape[0], X.shape[1], &out[0])
+    else:
+        out = np.zeros(X_indices.shape[0] * (X_indices.shape[0] - 1) / 2, dtype=np.double)
+        pdist_float_X_indices(&X[0, 0], metric, X.shape[0], X.shape[1],
+            &X_indices[0], X_indices.shape[0], &out[0])
+    return np.array(out, copy=False)
+
+
+cdef _dist_rmsd(X, y, npy_intp[::1] X_indices=None):
+    cdef npy_intp i, ii, j
+    assert (X.xyz.ndim == 3) and (y.xyz.ndim == 3) and \
+           (X.xyz.shape[2]) == 3 and (y.xyz.shape[2] == 3)
+    if not (X.xyz.shape[1]  == y.xyz.shape[1]):
+        raise ValueError("Input trajectories must have same number of atoms. "
+                         "found %d and %d." % (X.xyz.shape[1], y.xyz.shape[1]))
+
+    cdef double[::1] out
+    cdef float[:, :, ::1] X_xyz = X.xyz
+    cdef float[:, :, ::1] Y_xyz = y.xyz
+    cdef int n_atoms = X.xyz.shape[1]
+    cdef npy_intp X_length = X_xyz.shape[0]
+    cdef npy_intp y_length = Y_xyz.shape[0]
+    cdef float X_trace, Y_trace, rmsd
+
+    inplace_center_and_trace_atom_major(&Y_xyz[0, 0, 0], &Y_trace, 1, n_atoms)
+
+    if X_indices is None:
+        out = np.zeros(X_xyz.shape[0], dtype=np.double)
+        for i in range(X_xyz.shape[0]):
+            inplace_center_and_trace_atom_major(&X_xyz[i, 0, 0], &X_trace, 1, n_atoms)
+
+            out[i] = sqrt(msd_atom_major(n_atoms, n_atoms, &X_xyz[i, 0, 0],
+                          &Y_xyz[0, 0, 0], X_trace, Y_trace, 0, NULL))
+    else:
+        out = np.zeros(X_indices.shape[0], dtype=np.double)
+        for i in range(X_indices.shape[0]):
+            inplace_center_and_trace_atom_major(&X_xyz[X_indices[i], 0, 0], &X_trace, 1, n_atoms)
+
+            out[i] = sqrt(msd_atom_major(n_atoms, n_atoms, &X_xyz[X_indices[i], 0, 0],
+                          &Y_xyz[0, 0, 0], X_trace, Y_trace, 0, NULL))
+    return np.array(out, copy=False)
+
+
+cdef _dist_double(double[:, ::1] X, double[::1] y, char* metric, npy_intp[::1] X_indices=None):
+    cdef double[::1] out
+    assert X.shape[1] == y.shape[0]
+    if X_indices is None:
+        out = np.zeros(X.shape[0], dtype=np.double)
+        dist_double(&X[0,0], &y[0], metric, X.shape[0], X.shape[1], &out[0])
+    else:
+        out = np.zeros(X_indices.shape[0], dtype=np.double)
+        dist_double_X_indices(&X[0, 0], &y[0], metric, X.shape[0], X.shape[1],
+            &X_indices[0], X_indices.shape[0], &out[0])
+    return np.array(out, copy=False)
+
+
+cdef _dist_float(float[:, ::1] X, float[::1] y, char* metric, npy_intp[::1] X_indices=None):
+    cdef double[::1] out
+    assert X.shape[1] == y.shape[0]
+    if X_indices is None:
+        out = np.zeros(X.shape[0], dtype=np.double)
+        dist_float(&X[0,0], &y[0], metric, X.shape[0], X.shape[1], &out[0])
+    else:
+        out = np.zeros(X_indices.shape[0], dtype=np.double)
+        dist_float_X_indices(&X[0, 0], &y[0], metric, X.shape[0], X.shape[1],
+            &X_indices[0], X_indices.shape[0], &out[0])
+    return np.array(out, copy=False)

--- a/Mixtape/libdistance/src/assign.hpp
+++ b/Mixtape/libdistance/src/assign.hpp
@@ -1,0 +1,91 @@
+#include <cfloat>
+#include <cmath>
+#include "distance_kernels.h"
+
+
+double assign_nearest_double(const double* X, const double* Y,
+        const char* metric, const npy_intp* X_indices, npy_intp n_X,
+        npy_intp n_Y, npy_intp n_features, npy_intp n_X_indices,
+        npy_intp* assignments)
+{
+    double d = 0, min_d = 0, inertia = 0;
+    npy_intp i, j;
+    double (*metricfunc) (const double *u, const double *v, npy_intp n) = \
+        metric_double(metric);
+    if (metricfunc == NULL) {
+        fprintf(stderr, "Error");
+        return -1;
+    }
+    
+    if (X_indices == NULL) {
+        for (i = 0; i < n_X; i++) {
+            min_d = DBL_MAX;
+            for (j = 0; j < n_Y; j++) {
+                d = metricfunc(&X[i*n_features], &Y[j*n_features], n_features);
+                if (d < min_d) {
+                    min_d = d;
+                    assignments[i] = j;
+                }
+            }
+            inertia += min_d;
+        }
+    } else {
+        for (i = 0; i < n_X_indices; i++) {
+            min_d = DBL_MAX;
+            for (j = 0; j < n_Y; j++) {
+                d = metricfunc(&X[X_indices[i]*n_features], &Y[j*n_features], n_features);
+                if (d < min_d) {
+                    min_d = d;
+                    assignments[i] = j;
+                }
+            }
+            inertia += min_d;
+        }
+    }
+
+    return inertia;
+}
+
+
+double assign_nearest_float(const float* X, const float* Y,
+        const char* metric, const npy_intp* X_indices, npy_intp n_X,
+        npy_intp n_Y, npy_intp n_features, npy_intp n_X_indices,
+        npy_intp* assignments)
+{
+    double d = 0, min_d = 0, inertia = 0;
+    npy_intp i, j;
+    double (*metricfunc) (const float *u, const float *v, npy_intp n) = \
+        metric_float(metric);
+    if (metricfunc == NULL) {
+        fprintf(stderr, "Error");
+        return -1;
+    }
+    
+    if (X_indices == NULL) {
+        for (i = 0; i < n_X; i++) {
+            min_d = DBL_MAX;
+            for (j = 0; j < n_Y; j++) {
+                d = metricfunc(&X[i*n_features], &Y[j*n_features], n_features);
+                if (d < min_d) {
+                    min_d = d;
+                    assignments[i] = j;
+                }
+            }
+            inertia += min_d;
+        }
+    } else {
+        for (i = 0; i < n_X_indices; i++) {
+            min_d = DBL_MAX;
+            for (j = 0; j < n_Y; j++) {
+                d = metricfunc(&X[X_indices[i]*n_features], &Y[j*n_features], n_features);
+                if (d < min_d) {
+                    min_d = d;
+                    assignments[i] = j;
+                }
+            }
+            inertia += min_d;
+        }
+    }
+
+    return inertia;
+}

--- a/Mixtape/libdistance/src/dist.hpp
+++ b/Mixtape/libdistance/src/dist.hpp
@@ -1,0 +1,80 @@
+#include "distance_kernels.h"
+
+
+void dist_double(const double* X, const double* y, const char* metric, npy_intp n,
+                 npy_intp m, double* out)
+{
+    npy_intp i;
+    const double *u;
+    double (*metricfunc) (const double *u, const double *v, npy_intp n) = \
+        metric_double(metric);
+    if (metricfunc == NULL) {
+        fprintf(stderr, "Error");
+        return;
+    }
+    
+    for (i = 0; i < n; i++) {
+        u = X + m * i;
+        out[i] = metricfunc(u, y, m);
+    }
+}
+
+
+void dist_double_X_indices(const double* X, const double* y, const char* metric,
+                           npy_intp n, npy_intp m, const npy_intp* X_indices,
+                           npy_intp n_X_indices, double* out)
+{
+    npy_intp i, ii;
+    const double *u;
+    double (*metricfunc) (const double *u, const double *v, npy_intp n) = \
+        metric_double(metric);
+    if (metricfunc == NULL) {
+        fprintf(stderr, "Error");
+        return;
+    }
+    
+    for (ii = 0; ii < n_X_indices; ii++) {
+        i = X_indices[ii];
+        u = X + m * i;
+        out[ii] = metricfunc(u, y, m);
+    }
+}
+
+
+void dist_float(const float* X, const float* y, const char* metric, npy_intp n,
+                npy_intp m, double* out)
+{
+    npy_intp i;
+    const float *u;
+    double (*metricfunc) (const float *u, const float *v, npy_intp n) = \
+        metric_float(metric);
+    if (metricfunc == NULL) {
+        fprintf(stderr, "Error");
+        return;
+    }
+    
+    for (i = 0; i < n; i++) {
+        u = X + m * i;
+        out[i] = metricfunc(u, y, m);
+    }
+}
+
+void dist_float_X_indices(const float* X, const float* y, const char* metric,
+                          npy_intp n, npy_intp m, const npy_intp* X_indices,
+                          npy_intp n_X_indices, double* out)
+{
+    npy_intp i, ii;
+    const float *u;
+    double (*metricfunc) (const float *u, const float *v, npy_intp n) = \
+        metric_float(metric);
+    if (metricfunc == NULL) {
+        fprintf(stderr, "Error");
+        return;
+    }
+    
+    for (ii = 0; ii < n_X_indices; ii++) {
+        i = X_indices[ii];
+        u = X + m * i;
+        out[ii] = metricfunc(u, y, m);
+    }
+}

--- a/Mixtape/libdistance/src/distance_kernels.h
+++ b/Mixtape/libdistance/src/distance_kernels.h
@@ -1,0 +1,300 @@
+/**
+ * Author: Damian Eads
+ * Date:   September 22, 2007 (moved to new file on June 8, 2008)
+ *
+ * Copyright (c) 2007, 2008, Damian Eads. All rights reserved.
+ * Adapted for incorporation into Scipy, April 9, 2008.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *   - Redistributions of source code must retain the above
+ *     copyright notice, this list of conditions and the
+ *     following disclaimer.
+ *   - Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer
+ *     in the documentation and/or other materials provided with the
+ *     distribution.
+ *   - Neither the name of the author nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef MIXTAPE_LIBDISTANCE_KERNELS_H
+#define MIXTAPE_LIBDISTANCE_KERNELS_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static NPY_INLINE double
+sqeuclidean_distance_double(const double *u, const double *v, npy_intp n)
+{
+    double s = 0.0, d;
+    npy_intp i;
+
+    for (i = 0; i < n; i++) {
+        d = u[i] - v[i];
+        s += d * d;
+    }
+    return s;
+}
+
+static NPY_INLINE double
+sqeuclidean_distance_float(const float *u, const float *v, npy_intp n)
+{
+    double s = 0.0, d;
+    npy_intp i;
+
+    for (i = 0; i < n; i++) {
+        d = u[i] - v[i];
+        s += d * d;
+    }
+    return s;
+}
+
+static NPY_INLINE double
+euclidean_distance_double(const double *u, const double *v, npy_intp n)
+{
+    return sqrt(sqeuclidean_distance_double(u, v, n));
+}
+
+static NPY_INLINE double
+euclidean_distance_float(const float *u, const float *v, npy_intp n)
+{
+    return sqrt(sqeuclidean_distance_float(u, v, n));
+}
+
+static NPY_INLINE double
+chebyshev_distance_double(const double *u, const double *v, npy_intp n)
+{
+    double d, maxv = 0.0;
+    npy_intp i;
+
+    for (i = 0; i < n; i++) {
+        d = fabs(u[i] - v[i]);
+        if (d > maxv) {
+            maxv = d;
+        }
+    }
+    return maxv;
+}
+
+static NPY_INLINE double
+chebyshev_distance_float(const float *u, const float *v, npy_intp n)
+{
+    double d, maxv = 0.0;
+    npy_intp i;
+
+    for (i = 0; i < n; i++) {
+        d = fabs(u[i] - v[i]);
+        if (d > maxv) {
+            maxv = d;
+        }
+    }
+    return maxv;
+}
+
+static NPY_INLINE double
+canberra_distance_double(const double *u, const double *v, npy_intp n)
+{
+    double snum = 0.0, sdenom = 0.0, tot = 0.0;
+    npy_intp i;
+
+    for (i = 0; i < n; i++) {
+        snum = fabs(u[i] - v[i]);
+        sdenom = fabs(u[i]) + fabs(v[i]);
+        if (sdenom > 0.0) {
+            tot += snum / sdenom;
+        }
+    }
+    return tot;
+}
+
+static NPY_INLINE double
+canberra_distance_float(const float *u, const float *v, npy_intp n)
+{
+    double snum = 0.0, sdenom = 0.0, tot = 0.0;
+    npy_intp i;
+
+    for (i = 0; i < n; i++) {
+        snum = fabs(u[i] - v[i]);
+        sdenom = fabs(u[i]) + fabs(v[i]);
+        if (sdenom > 0.0) {
+            tot += snum / sdenom;
+        }
+    }
+    return tot;
+}
+
+static NPY_INLINE double
+bray_curtis_distance_double(const double *u, const double *v, npy_intp n)
+{
+    double s1 = 0.0, s2 = 0.0;
+    npy_intp i;
+
+    for (i = 0; i < n; i++) {
+        s1 += fabs(u[i] - v[i]);
+        s2 += fabs(u[i] + v[i]);
+    }
+    return s1 / s2;
+}
+
+static NPY_INLINE double
+bray_curtis_distance_float(const float *u, const float *v, npy_intp n)
+{
+    double s1 = 0.0, s2 = 0.0;
+    npy_intp i;
+
+    for (i = 0; i < n; i++) {
+        s1 += fabs(u[i] - v[i]);
+        s2 += fabs(u[i] + v[i]);
+    }
+    return s1 / s2;
+}
+
+static NPY_INLINE double
+hamming_distance_double(const double *u, const double *v, npy_intp n)
+{
+    double s = 0.0;
+    npy_intp i;
+
+    for (i = 0; i < n; i++) {
+        s += (u[i] != v[i]);
+    }
+    return s / n;
+}
+
+static NPY_INLINE double
+hamming_distance_float(const float *u, const float *v, npy_intp n)
+{
+    double s = 0.0;
+    npy_intp i;
+
+    for (i = 0; i < n; i++) {
+        s += (u[i] != v[i]);
+    }
+    return s / n;
+}
+
+static NPY_INLINE double
+jaccard_distance_double(const double *u, const double *v, npy_intp n)
+{
+    double denom = 0.0, num = 0.0;
+    npy_intp i;
+
+    for (i = 0; i < n; i++) {
+        num += (u[i] != v[i]) & ((u[i] != 0.0) | (v[i] != 0.0));
+        denom += (u[i] != 0.0) | (v[i] != 0.0);
+    }
+    return num / denom;
+}
+
+static NPY_INLINE double
+jaccard_distance_float(const float *u, const float *v, npy_intp n)
+{
+    double denom = 0.0, num = 0.0;
+    npy_intp i;
+
+    for (i = 0; i < n; i++) {
+        num += (u[i] != v[i]) & ((u[i] != 0.0) | (v[i] != 0.0));
+        denom += (u[i] != 0.0) | (v[i] != 0.0);
+    }
+    return num / denom;
+}
+
+
+static NPY_INLINE double
+city_block_distance_double(const double *u, const double *v, npy_intp n)
+{
+    double s = 0.0, d;
+    npy_intp i;
+
+    for (i = 0; i < n; i++) {
+        d = fabs(u[i] - v[i]);
+        s = s + d;
+    }
+    return s;
+}
+
+static NPY_INLINE double
+city_block_distance_float(const float *u, const float *v, npy_intp n)
+{
+    double s = 0.0, d;
+    npy_intp i;
+
+    for (i = 0; i < n; i++) {
+        d = fabs(u[i] - v[i]);
+        s = s + d;
+    }
+    return s;
+}
+
+
+static double(*metric_double(const char* metric))
+  (const double *u, const double *v, npy_intp n)
+{
+    if (strcmp(metric, "euclidean") == 0) {
+        return &euclidean_distance_double;  
+    } else if (strcmp(metric, "sqeuclidean") == 0) {
+        return &sqeuclidean_distance_double;
+    } else if (strcmp(metric, "cityblock") == 0) {
+      return &city_block_distance_double;
+    } else if (strcmp(metric, "chebyshev") == 0) {
+      return &chebyshev_distance_double;
+    } else if (strcmp(metric, "canberra") == 0) {
+      return &canberra_distance_double;
+    } else if (strcmp(metric, "braycurtis") == 0) {
+      return &bray_curtis_distance_double;
+    } else if (strcmp(metric, "hamming") == 0) {
+      return &hamming_distance_double;
+    } else if (strcmp(metric, "jaccard") == 0) {
+      return &jaccard_distance_double;
+    } else if (strcmp(metric, "cityblock") == 0) {
+      return &city_block_distance_double;
+    }
+    return NULL;
+}
+
+static double(*metric_float(const char* metric))
+  (const float *u, const float *v, npy_intp n)
+{
+    if (strcmp(metric, "euclidean") == 0) {
+        return &euclidean_distance_float;  
+    } else if (strcmp(metric, "sqeuclidean") == 0) {
+        return &sqeuclidean_distance_float;
+    } else if (strcmp(metric, "cityblock") == 0) {
+      return &city_block_distance_float;
+    } else if (strcmp(metric, "chebyshev") == 0) {
+      return &chebyshev_distance_float;
+    } else if (strcmp(metric, "canberra") == 0) {
+      return &canberra_distance_float;
+    } else if (strcmp(metric, "braycurtis") == 0) {
+      return &bray_curtis_distance_float;
+    } else if (strcmp(metric, "hamming") == 0) {
+      return &hamming_distance_float;
+    } else if (strcmp(metric, "jaccard") == 0) {
+      return &jaccard_distance_float;
+    } else if (strcmp(metric, "cityblock") == 0) {
+      return &city_block_distance_float;
+    }
+    return NULL;
+}
+
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/Mixtape/libdistance/src/pdist.hpp
+++ b/Mixtape/libdistance/src/pdist.hpp
@@ -1,0 +1,96 @@
+#include "distance_kernels.h"
+
+
+void pdist_double(const double* X, const char* metric, npy_intp n, npy_intp m,
+                  double* out)
+{
+    npy_intp i, j, k;
+    const double *u, *v;
+    double (*metricfunc) (const double *u, const double *v, npy_intp n) = \
+        metric_double(metric);
+    if (metricfunc == NULL) {
+        fprintf(stderr, "Error");
+        return;
+    }
+    
+    k = 0;
+    for (i = 0; i < n; i++) {
+        for (j = i+1; j < n; j++) {
+            u = X + m * i;
+            v = X + m * j;
+            out[k++] = metricfunc(u, v, m);
+        }
+    }
+}
+
+void pdist_double_X_indices(const double* X, const char* metric, npy_intp n,
+                            npy_intp m, const npy_intp* X_indices,
+                            npy_intp n_X_indices, double* out)
+{
+    npy_intp i, ii, j, jj, k;
+    const double *u, *v;
+    double (*metricfunc) (const double *u, const double *v, npy_intp n) = \
+        metric_double(metric);
+    if (metricfunc == NULL) {
+        fprintf(stderr, "Error");
+        return;
+    }
+    
+    k = 0;
+    for (ii = 0; ii < n_X_indices; ii++) {
+        i = X_indices[ii];
+        for (jj = ii+1; jj < n_X_indices; jj++) {
+            j = X_indices[jj];
+            u = X + m * i;
+            v = X + m * j;
+            out[k++] = metricfunc(u, v, m);
+        }
+    }
+}
+
+
+void pdist_float(const float* X, const char* metric, npy_intp n, npy_intp m,
+                 double* out)
+{
+    npy_intp i, j, k;
+    const float *u, *v;
+    double (*metricfunc) (const float *u, const float *v, npy_intp n) = \
+        metric_float(metric);
+    if (metricfunc == NULL) {
+        fprintf(stderr, "Error");
+        return;
+    }
+    
+    k = 0;
+    for (i = 0; i < n; i++) {
+        for (j = i+1; j < n; j++) {
+            u = X + m * i;
+            v = X + m * j;
+            out[k++] = metricfunc(u, v, m);
+        }
+    }
+}
+void pdist_float_X_indices(const float* X, const char* metric, npy_intp n,
+                           npy_intp m, const npy_intp* X_indices,
+                           npy_intp n_X_indices, double* out)
+{
+    npy_intp i, ii, j, jj, k;
+    const float *u, *v;
+    double (*metricfunc) (const float *u, const float *v, npy_intp n) = \
+        metric_float(metric);
+    if (metricfunc == NULL) {
+        fprintf(stderr, "Error");
+        return;
+    }
+    
+    k = 0;
+    for (ii = 0; ii < n_X_indices; ii++) {
+        i = X_indices[ii];
+        for (jj = ii+1; jj < n_X_indices; jj++) {
+            j = X_indices[jj];
+            u = X + m * i;
+            v = X + m * j;
+            out[k++] = metricfunc(u, v, m);
+        }
+    }
+}

--- a/Mixtape/tests/test_libdistance.py
+++ b/Mixtape/tests/test_libdistance.py
@@ -1,0 +1,174 @@
+import numpy as np
+import mdtraj as md
+import scipy.spatial.distance
+from mixtape.libdistance import assign_nearest, pdist, dist
+from mixtape.datasets import AlanineDipeptide
+
+random = np.random.RandomState(0)
+X_double = random.randn(10, 2)
+Y_double = random.randn(3, 2)
+X_float = random.randn(10, 2).astype(np.float32)
+Y_float = np.random.randn(3, 2).astype(np.float32)
+X_rmsd = AlanineDipeptide().get().trajectories[0][0:10]
+Y_rmsd = AlanineDipeptide().get().trajectories[0][10:13]
+
+X_indices = random.random_integers(low=0, high=9, size=5)
+
+VECTOR_METRICS = ("euclidean", "sqeuclidean", "cityblock", "chebyshev",
+                  "canberra", "braycurtis", "hamming", "jaccard", "cityblock")
+
+
+def test_assign_nearest_double_float_1():
+    # test without X_indices
+    for metric in VECTOR_METRICS:
+        for X, Y in ((X_double, Y_double), (X_float, Y_float)):
+            assignments, inertia = assign_nearest(X, Y, metric)
+            assert isinstance(assignments, np.ndarray)
+            assert isinstance(inertia, float)
+
+            cdist = scipy.spatial.distance.cdist(X, Y, metric=metric)
+            assert cdist.shape == (10, 3)
+            yield lambda: np.testing.assert_array_equal(
+                assignments,
+                cdist.argmin(axis=1))
+
+            yield lambda: np.testing.assert_almost_equal(
+                inertia,
+                cdist[np.arange(10), assignments].sum(),
+                decimal=5)
+
+
+def test_assign_nearest_float_double_2():
+    # test with X_indices
+
+    for metric in VECTOR_METRICS:
+        for X, Y in ((X_double, Y_double), (X_float, Y_float)):
+
+            assignments, inertia = assign_nearest(X, Y, metric, X_indices)
+            assert isinstance(assignments, np.ndarray)
+            assert isinstance(inertia, float)
+
+            cdist = scipy.spatial.distance.cdist(X[X_indices], Y, metric=metric)
+            yield lambda: np.testing.assert_array_equal(
+                assignments,
+                cdist.argmin(axis=1))
+            yield lambda: np.testing.assert_almost_equal(
+                inertia,
+                cdist[np.arange(5), assignments].sum(),
+                decimal=5)
+
+
+def test_assign_nearest_rmsd_1():
+    # rmsd assign nearest without X_indices
+    assignments, inertia = assign_nearest(X_rmsd, Y_rmsd, "rmsd")
+    assert isinstance(assignments, np.ndarray)
+    assert isinstance(inertia, float)
+
+    cdist = np.array([md.rmsd(X_rmsd, Y_rmsd[i]) for i in range(len(Y_rmsd))]).T
+    assert cdist.shape == (10, 3)
+
+    np.testing.assert_array_equal(
+        assignments,
+        cdist.argmin(axis=1))
+
+    np.testing.assert_almost_equal(
+        inertia,
+        cdist[np.arange(10), assignments].sum(),
+        decimal=5)
+
+
+def test_assign_nearest_rmsd_2():
+    # rmsd assign nearest with X_indices
+    assignments, inertia = assign_nearest(X_rmsd, Y_rmsd, "rmsd", X_indices)
+    assert isinstance(assignments, np.ndarray)
+    assert isinstance(inertia, float)
+
+    cdist = np.array([md.rmsd(X_rmsd, Y_rmsd[i]) for i in range(len(Y_rmsd))]).T
+    cdist = cdist[X_indices]
+    assert cdist.shape == (5, 3)
+
+    np.testing.assert_array_equal(
+        assignments,
+        cdist.argmin(axis=1))
+
+    np.testing.assert_almost_equal(
+        inertia,
+        cdist[np.arange(5), assignments].sum(),
+        decimal=5)
+
+
+def test_pdist_double_float_1():
+    # test without X_indices
+    for metric in VECTOR_METRICS:
+        for X, Y in ((X_double, Y_double), (X_float, Y_float)):
+            pdist_1 = pdist(X, metric)
+            pdist_2 = scipy.spatial.distance.pdist(X, metric)
+            yield lambda : np.testing.assert_almost_equal(
+                pdist_1,
+                pdist_2,
+                decimal=5)
+
+
+def test_pdist_double_float_2():
+    # test without X_indices
+    for metric in VECTOR_METRICS:
+        for X, Y in ((X_double, Y_double), (X_float, Y_float)):
+            pdist_1 = pdist(X, metric, X_indices=X_indices)
+            pdist_2 = scipy.spatial.distance.pdist(X[X_indices], metric)
+            yield lambda : np.testing.assert_almost_equal(
+                pdist_1,
+                pdist_2,
+                decimal=5)
+
+
+def test_pdist_rmsd_1():
+    got = pdist(X_rmsd, "rmsd")
+    all2all = np.array([md.rmsd(X_rmsd, X_rmsd[i]) for i in range(len(X_rmsd))])
+    ref = all2all[np.triu_indices(10, k=1)]
+    np.testing.assert_almost_equal(got, ref, decimal=5)
+
+
+def test_pdist_rmsd_2():
+    got = pdist(X_rmsd, "rmsd", X_indices)
+    all2all = np.array([md.rmsd(X_rmsd, X_rmsd[i])
+                        for i in range(len(X_rmsd))]).astype(np.double)
+    submatrix = all2all[np.ix_(X_indices, X_indices)]
+
+    ref = submatrix[np.triu_indices(5, k=1)]
+    np.testing.assert_almost_equal(got, ref, decimal=4)
+
+
+def test_dist_double_float_1():
+    # test without X_indices
+    for metric in VECTOR_METRICS:
+        for X, Y in ((X_double, Y_double), (X_float, Y_float)):
+            dist_1 = dist(X, Y[0], metric)
+            dist_2 = scipy.spatial.distance.cdist(X, [Y[0]], metric)[:,0]
+            yield lambda : np.testing.assert_almost_equal(
+                dist_1,
+                dist_2,
+                decimal=5)
+
+
+def test_dist_double_float_2():
+    # test with X_indices
+    for metric in VECTOR_METRICS:
+        for X, Y in ((X_double, Y_double), (X_float, Y_float)):
+            dist_1 = dist(X, Y[0], metric, X_indices)
+            dist_2 = scipy.spatial.distance.cdist(X, [Y[0]], metric)[X_indices,0]
+            yield lambda : np.testing.assert_almost_equal(
+                dist_1,
+                dist_2,
+                decimal=5)
+
+
+def test_dist_rmsd_1():
+    d = dist(X_rmsd, Y_rmsd[0], "rmsd")
+    ref = md.rmsd(X_rmsd, Y_rmsd[0]).astype(np.double)
+    np.testing.assert_array_almost_equal(d, ref)
+
+
+def test_dist_rmsd_2():
+    d = dist(X_rmsd, Y_rmsd[0], "rmsd", X_indices)
+    ref = md.rmsd(X_rmsd, Y_rmsd[0]).astype(np.double)[X_indices]
+    np.testing.assert_array_almost_equal(d, ref)

--- a/devtools/ci/after_sucess.sh
+++ b/devtools/ci/after_sucess.sh
@@ -1,6 +1,6 @@
 echo $TRAVIS_PULL_REQUEST $TRAVIS_BRANCH
 
-if [[ "$TRAVIS_PULL_REQUEST" == "true" ]]; then
+if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then
     echo "This is a pull request. No deployment will be done."; exit 0
 fi
 

--- a/devtools/ci/requirements.txt
+++ b/devtools/ci/requirements.txt
@@ -3,7 +3,7 @@ pytables
 cython
 pandas
 nose
-mdtraj
+mdtraj-dev
 scikit-learn
 numpydoc
 ipython


### PR DESCRIPTION
re #299 Three generic public functions, `assign_nearest`, `pdist`, and `dist`, which operate with any of the vector distance metrics on double or float, or rmsd on mdtraj trajectories. I think most of the cython library can be removed and replaced with calls to this.
