### PR TITLE
Add instructions for how to load datasets, objects in command line

### DIFF
--- a/Mixtape/cmdline.py
+++ b/Mixtape/cmdline.py
@@ -54,6 +54,7 @@ if __name__ == '__main__':
 from __future__ import print_function, division, absolute_import
 from six import with_metaclass
 import re
+import os
 import sys
 import abc
 import copy
@@ -445,3 +446,12 @@ class MyHelpFormatter(argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescri
         action_max_length = kwargs.pop('action_max_length', 0)
         super(MyHelpFormatter, self).__init__(*args, **kwargs)
         self._action_max_length = action_max_length
+
+def exttype(suffix):
+    """Type for use with argument(... type=) that will force a specific suffix
+    Especially for output files, so that we can enforce the use of appropriate
+    file-type specific suffixes"""
+    def inner(s):
+        first, last = os.path.splitext(s)
+        return first + suffix
+    return inner

--- a/Mixtape/commands/featurizer.py
+++ b/Mixtape/commands/featurizer.py
@@ -5,7 +5,7 @@ import sys
 import numpy as np
 import mdtraj as md
 
-from ..cmdline import NumpydocClassCommand, argument
+from ..cmdline import NumpydocClassCommand, argument, exttype
 from ..dataset import dataset, MDTrajDataset
 from ..featurizer import (AtomPairsFeaturizer, SuperposeFeaturizer,
                           DRIDFeaturizer, DihedralFeaturizer,
@@ -24,7 +24,7 @@ class FeaturizerCommand(NumpydocClassCommand):
         help='''Chunk size for loading trajectories using mdtraj.iterload''',
         default=10000, type=int)
     out = argument(
-        '--out', required=True, help='Output path')
+        '--out', required=True, help='Output path', type=exttype('/'))
     stride = argument(
         '--stride', default=1, type=int,
         help='Load only every stride-th frame')
@@ -49,7 +49,12 @@ class FeaturizerCommand(NumpydocClassCommand):
             print()
             out_dataset[key] = np.concatenate(trajectory)
 
-        print('All done')
+        print("\nSaving transformed dataset to '%s'" % self.out)
+        print("To load this dataset interactive inside an IPython")
+        print("shell or notebook, run\n")
+        print("  $ ipython")
+        print("  >>> from mixtape.dataset import dataset")
+        print("  >>> ds = dataset('%s')\n" % self.out)
 
 
 class DihedralFeaturizerCommand(FeaturizerCommand):

--- a/Mixtape/commands/fit.py
+++ b/Mixtape/commands/fit.py
@@ -25,7 +25,7 @@ from ..dataset import dataset
 from ..utils import verbosedump
 from ..hmm import GaussianFusionHMM
 from ..msm import MarkovStateModel, BayesianMarkovStateModel
-from ..cmdline import NumpydocClassCommand, argument
+from ..cmdline import NumpydocClassCommand, argument, exttype
 
 
 class FitCommand(NumpydocClassCommand):
@@ -34,18 +34,24 @@ class FitCommand(NumpydocClassCommand):
         list of numpy arrays.''', required=True)
     model = argument(
         '--out', help='''Output (fit) model. This will be a
-        serialized instance of the fit model object.''', required=True)
+        serialized instance of the fit model object.''', required=True, type=exttype('.pkl'))
 
     def start(self):
         print(self.instance)
 
         ds = dataset(self.inp, mode='r', fmt='dir-npy')
         self.instance.fit(ds)
-        verbosedump(self.instance, self.out)
 
         print("*********\n*RESULTS*\n*********")
         print(self.instance.summarize())
-        print('All done')
+        print('-' * 80)
+
+        verbosedump(self.instance, self.out)
+        print("To load this %s object interactively inside an IPython\n"
+              "shell or notebook, run: \n" % self.klass.__name__)
+        print("  $ ipython")
+        print("  >>> from mixtape.utils import load")
+        print("  >>> model = load('%s')\n" % self.out)
 
 
 class GaussianFusionHMMCommand(FitCommand):


### PR DESCRIPTION
Here's the stdout stream for running KCenters from the command line, using this PR

```
$ msmb KCenters --n_clusters 100 --inp atom_pairs --transformed kcenters --out model.pkl
KCenters(metric='euclidean', n_clusters=100, random_state=None)
*********
*RESULTS*
*********

KCenters clustering
--------------------
n_clusters : 100
metric     : euclidean

Inertia       : 7689.59786338
Mean distance : 0.0768967476013
Max  distance : 0.111259981904

--------------------------------------------------------------------------------
Saving transformed dataset to 'kcenters/'
To load this dataset interactive inside an IPython
shell or notebook, run

  $ ipython
  >>> from mixtape.dataset import dataset
  >>> ds = dataset('kcenters/')

Saving "model.pkl"... (<class 'mixtape.cluster.kcenters.KCenters'>)
To load this KCenters object interactively inside an IPython
shell or notebook, run:

  $ ipython
  >>> from mixtape.utils import load
  >>> model = load('model.pkl')
```
