### PR TITLE
[ENH] Wrap unexpected tracebacks

### DIFF
--- a/msmbuilder/scripts/msmb.py
+++ b/msmbuilder/scripts/msmb.py
@@ -26,7 +26,7 @@ def main():
 An unexpected error has occurred with MSMBuilder (version %s), please
 consider sending the following traceback to MSMBuilder GitHub issue tracker at:
             https://github.com/msmbuilder/msmbuilder/issues
-    """
+"""
         print(message % version, file=sys.stderr)
         raise  # as if we did not catch it
 


### PR DESCRIPTION
e.g. from the command line

```
[... etc ...]
An unexpected error has occurred with MSMBuilder (version 3.0.0-beta.dev-1b2b3c1), please
consider sending the following traceback to MSMBuilder GitHub issue tracker at:
            https://github.com/msmbuilder/msmbuilder/issues

Traceback (most recent call last):
  File "/Users/rmcgibbo/miniconda/envs/3.3/bin/msmb", line 9, in <module>
    load_entry_point('msmbuilder==3.0.0-beta', 'console_scripts', 'msmb')()
  File "/Users/rmcgibbo/projects/mixtape/msmbuilder/scripts/msmb.py", line 21, in main
    app.start()
  File "/Users/rmcgibbo/projects/mixtape/msmbuilder/cmdline.py", line 413, in start
    instance.start()
  File "/Users/rmcgibbo/projects/mixtape/msmbuilder/commands/implied_timescales.py", line 90, in start
    raise ValueError()
ValueError
```
