### PR TITLE
[ENH] Warn about dependencies in setup.py 

### DIFF
--- a/basesetup.py
+++ b/basesetup.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, absolute_import
 import os
 import sys
+import imp
 import json
 import string
 import shutil
@@ -28,6 +29,36 @@ def find_packages():
         packages.append(package.replace('MDTraj', 'mdtraj'))
     return packages
 
+
+def check_dependencies(dependencies):
+    def module_exists(dep):
+        try:
+            imp.find_module(dep)
+            return True
+        except ImportError:
+            return False
+
+    for dep in dependencies:
+        if len(dep) == 1:
+            import_name, pkg_name = dep[0], dep[0]
+        elif len(dep) == 2:
+            import_name, pkg_name = dep
+        else:
+            raise ValueError(dep)
+
+        if not module_exists(import_name):
+            lines = [
+                '-' * 50,
+                'Warning: This package requires %r. Try' % import_name,
+                '',
+                '  $ conda install %s' % pkg_name,
+                '',
+                'or:',
+                '',
+                '  $ pip install %s' % pkg_name,
+                '-' * 50,
+            ]
+            print(os.linesep.join(lines), file=sys.stderr)
 
 
 ################################################################################

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from setuptools import setup, Extension, find_packages
 try:
     sys.dont_write_bytecode = True
     sys.path.insert(0, '.')
-    from basesetup import write_version_py, CompilerDetection
+    from basesetup import write_version_py, CompilerDetection, check_dependencies
 finally:
     sys.dont_write_bytecode = False
 
@@ -76,6 +76,19 @@ Programming Language :: Python :: 3
 Programming Language :: Python :: 3.3
 Programming Language :: Python :: 3.4
 """
+
+if any(cmd in sys.argv for cmd in ('install', 'build', 'develop')):
+    check_dependencies((
+        ('numpy',),
+        ('scipy',),
+        ('pandas',),
+        ('six',),
+        ('mdtraj',),
+        ('sklearn', 'scikit-learn'),
+        ('numpydoc',),
+        ('tables', 'pytables'),
+    ))
+
 
 # Where to find extensions
 MSMDIR = 'msmbuilder/msm/'


### PR DESCRIPTION
Addresses #324. If you don't have one of the required packages installed, you'll get a warning like

```
$ python setup.py build
--------------------------------------------------
Warning: This package requires 'scipy'. Try

  $ conda install scipy

or:

  $ pip install scipy
--------------------------------------------------
```
