### PR TITLE
Fix intermitent error on implied timescaels with shape

### DIFF
--- a/msmbuilder/msm/implied_timescales.py
+++ b/msmbuilder/msm/implied_timescales.py
@@ -46,6 +46,7 @@ def implied_timescales(sequences, lag_times, n_timescales=10,
     param_grid = {'lag_time' : lag_times}
     models = param_sweep(msm, sequences, param_grid, n_jobs=n_jobs,
                          verbose=verbose)
-    timescales = np.array([model.timescales_[:n_timescales] for model in models])
-
+    timescales = [m.timescales_ for m in models]
+    n_timescales = min(n_timescales, min(len(ts) for ts in timescales))
+    timescales = np.array([ts[:n_timescales] for ts in timescales])
     return timescales


### PR DESCRIPTION
There are still some multiprocessing-specific errors with n_jobs > 1 in `msmb Impliedtimescales`

```
[Parallel(n_jobs=2)]: Done   1 out of  10 | elapsed:    3.3s remaining:   29.8s
[Parallel(n_jobs=2)]: Done  10 out of  10 | elapsed:    3.3s finished
An unexpected error has occurred with MSMBuilder (version 3.0.0-beta.dev-7c35b0b), please
consider sending the following traceback to MSMBuilder GitHub issue tracker at:
            https://github.com/msmbuilder/msmbuilder/issues
Traceback (most recent call last):
  File "/home/travis/miniconda/envs/_test/bin/msmb", line 6, in <module>
    sys.exit(main())
  File "/home/travis/miniconda/envs/_test/lib/python2.7/site-packages/msmbuilder-3.0.0_beta-py2.7-linux-x86_64.egg/msmbuilder/scripts/msmb.py", line 21, in main
    app.start()
  File "/home/travis/miniconda/envs/_test/lib/python2.7/site-packages/msmbuilder-3.0.0_beta-py2.7-linux-x86_64.egg/msmbuilder/cmdline.py", line 421, in start
    instance.start()
  File "/home/travis/miniconda/envs/_test/lib/python2.7/site-packages/msmbuilder-3.0.0_beta-py2.7-linux-x86_64.egg/msmbuilder/commands/implied_timescales.py", line 104, in start
    df = pd.DataFrame(data=lines, columns=cols)
  File "/home/travis/miniconda/envs/_test/lib/python2.7/site-packages/pandas/core/frame.py", line 239, in __init__
    copy=copy)
  File "/home/travis/miniconda/envs/_test/lib/python2.7/site-packages/pandas/core/frame.py", line 399, in _init_ndarray
    return create_block_manager_from_blocks([values.T], [columns, index])
  File "/home/travis/miniconda/envs/_test/lib/python2.7/site-packages/pandas/core/internals.py", line 3572, in create_block_manager_from_blocks
    construction_error(tot_items, blocks[0].shape[1:], axes, e)
  File "/home/travis/miniconda/envs/_test/lib/python2.7/site-packages/pandas/core/internals.py", line 3553, in construction_error
    passed,implied))
ValueError: Shape of passed values is (1, 10), indices imply (10, 10)
```
