### PR TITLE
Fixed bug in NDGrid clusterer

### DIFF
--- a/msmbuilder/cluster/ndgrid.py
+++ b/msmbuilder/cluster/ndgrid.py
@@ -119,7 +119,7 @@ class _NDGrid(ClusterMixin, TransformerMixin):
         binassign = np.zeros((self.n_features, len(X)), dtype=int)
         for i in range(self.n_features):
             binassign[i] = np.digitize(X[:, i], self.grid[i]) - 1
-        labels = np.dot(self.n_features**np.arange(self.n_features), binassign)
+        labels = np.dot(self.n_bins_per_feature**np.arange(self.n_features), binassign)
 
         assert np.max(labels) < self.n_bins
         return labels

--- a/msmbuilder/tests/test_ndgrid.py
+++ b/msmbuilder/tests/test_ndgrid.py
@@ -1,5 +1,6 @@
 import numpy as np
 from msmbuilder.cluster import NDGrid
+import itertools
 
 def test_ndgrid_1():
     X = np.array([-3, -2, -1, 1, 2, 3]).reshape(-1, 1)
@@ -19,4 +20,15 @@ def test_ndgrid_2():
     mask3 = np.logical_and(X[:, 0] > 0, X[:, 1] > 0)
     assert np.all(labels[mask3] == 3)
 
+def test_ndgrid_3():
+    X = np.random.RandomState(0).randn(100, 3)
+    labels = NDGrid(n_bins_per_feature=2, min=-5, max=5).fit([X]).predict([X])[0]
 
+    operators = [np.less, np.greater]
+    x = X[:, 0]
+    y = X[:, 1]
+    z = X[:, 2]
+
+    for indx, (op_z, op_y, op_x) in enumerate(itertools.product(operators, repeat=3)):
+        mask = np.logical_and.reduce((op_x(x, 0), op_y(y, 0), op_z(z, 0)))
+        assert np.all(labels[mask] == indx)


### PR DESCRIPTION
While playing around with the `NDGrid` clusterer, I found a bug that wasn't covered by the unit test set. This PR fixes the bug and adds a test for a 3-dimensional set of coordinates (where I stumbled on the issue initially). 
