### PR TITLE
use observed rather than scaled transition counts for ergodic trim

### DIFF
--- a/msmbuilder/msm/bayesmsm.py
+++ b/msmbuilder/msm/bayesmsm.py
@@ -180,7 +180,7 @@ class BayesianMarkovStateModel(BaseEstimator, _MappingTransformMixin):
 
         if self.ergodic_cutoff >= 1:
             self.countsmat_, mapping2 = _strongly_connected_subgraph(
-                raw_counts, self.ergodic_cutoff, self.verbose)
+                self.lag_time * raw_counts, self.ergodic_cutoff, self.verbose)
             self.mapping_ = _dict_compose(mapping, mapping2)
         else:
             self.countsmat_ = raw_counts

--- a/msmbuilder/msm/msm.py
+++ b/msmbuilder/msm/msm.py
@@ -161,7 +161,7 @@ class MarkovStateModel(BaseEstimator, _MappingTransformMixin):
             # step 2. restrict the counts to the maximal strongly ergodic
             # subgraph
             self.countsmat_, mapping2 = _strongly_connected_subgraph(
-                raw_counts, self.ergodic_cutoff, self.verbose)
+                self.lag_time * raw_counts, self.ergodic_cutoff, self.verbose)
             self.mapping_ = _dict_compose(mapping, mapping2)
         else:
             # no ergodic trimming.


### PR DESCRIPTION
This is a simple fix to https://github.com/msmbuilder/msmbuilder/issues/436 which simply multiplies the count matrices by the lag time when calculating the strong connected component for the ergodic trim. It's maybe not the most elegant solution, but it at least temporarily makes the algorithm consistent with the docstrings and removes the unexpected behavior that I encountered. Additionally I'm now getting comparable results for a system that I had previously analyzed with MSMBuilder2 using similar settings.