### PR TITLE
Asymptotic eigenvalue and timescale uncertainty estimators

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ branches:
 install:
   - source devtools/ci/install.sh
   - export PYTHONUNBUFFERED=true
+  # start Virtual X, so default matplotlib backend works
+  - "export DISPLAY=:99.0"
+  - "sh -e /etc/init.d/xvfb start"
 
 script:
   # this builds the binary, unpacks it, and runs the tests

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -17,7 +17,7 @@ requirements:
   build:
     - python
     - setuptools
-    - cython    
+    - cython
     - numpy
     - mdtraj
   run:
@@ -38,13 +38,14 @@ test:
     - nose
     - munkres
     - numdifftools
+    - matplotlib
   imports:
     - msmbuilder
   commands:
     - msmb -h
     - nosetests msmbuilder -v
-  
-  
+
+
 about:
   home: https://github.com/msmbuilder/msmbuilder
   license: LGPLv2.1+

--- a/msmbuilder/msm/msm.py
+++ b/msmbuilder/msm/msm.py
@@ -657,8 +657,9 @@ Timescales:
             for i in range(self.n_states_):
                 ui = self.countsmat_[:, i]
                 wi = np.sum(ui)
-                covariance = wi*np.diag(ui) - np.outer(ui, ui)
-                sigma2[k] += dLambda_dT[i].dot(covariance).dot(dLambda_dT[i]) / (wi**2*(wi+1))
+                cov = wi*np.diag(ui) - np.outer(ui, ui)
+                quad_form = dLambda_dT[i].dot(cov).dot(dLambda_dT[i])
+                sigma2[k] += quad_form / (wi**2*(wi+1))
         return np.sqrt(sigma2)
 
     def uncertainty_timescales(self):

--- a/msmbuilder/msm/msm.py
+++ b/msmbuilder/msm/msm.py
@@ -643,6 +643,8 @@ Timescales:
            the distribution of eigenvalues and eigenvectors in Markovian state
            models for molecular dynamics." J. Chem. Phys. 126.24 (2007): 244101.
         """
+        if self.reversible_type is None:
+            raise NotImplementedError('reversible_type must be "mle" or "transpose"')
 
         n_timescales = min(self.n_timescales, self.n_states_ - 1)
         if n_timescales is None:
@@ -675,14 +677,14 @@ Timescales:
            the distribution of eigenvalues and eigenvectors in Markovian state
            models for molecular dynamics." J. Chem. Phys. 126.24 (2007): 244101.
         """
+        if self.reversible_type is None:
+            raise NotImplementedError('reversible_type must be "mle" or "transpose"')
 
-        n_timescales = min(self.n_timescales, self.n_states_ - 1)
-        if n_timescales is None:
-            n_timescales = self.n_states_ - 1
         u, lv, rv = self._get_eigensystem()
 
-        sigma2 = np.zeros(n_timescales + 1)
-        sigma2_eigs = self.uncertainty_eigenvalues()
-        for k in range(n_timescales + 1):
-            sigma2[k] = sigma2_eigs[k] / (u[k] * np.log(u[k])**2)
-        return sigma2[1:]
+        sigma_eigs = self.uncertainty_eigenvalues()
+        sigma_ts = np.zeros_like(sigma_eigs)
+
+        for k in range(len(sigma_eigs)-1):
+            sigma_ts[k] = sigma_eigs[k] / (u[k] * np.log(u[k])**2)
+        return sigma_ts[1:]   # drop the first eigenvalue

--- a/msmbuilder/msm/msm.py
+++ b/msmbuilder/msm/msm.py
@@ -678,7 +678,9 @@ Timescales:
            the distribution of eigenvalues and eigenvectors in Markovian state
            models for molecular dynamics." J. Chem. Phys. 126.24 (2007): 244101.
         """
-        u, lv, rv = self._get_eigensystem()
-        sigma_eigs = self.uncertainty_eigenvalues()
+        # drop the first eigenvalue
+        u = self.eigenvalues_[1:]
+        sigma_eigs = self.uncertainty_eigenvalues()[1:]
+
         sigma_ts = sigma_eigs / (u * np.log(u)**2)
-        return sigma_ts[1:]  # drop the first eigenvalue
+        return sigma_ts

--- a/msmbuilder/msm/msm.py
+++ b/msmbuilder/msm/msm.py
@@ -677,14 +677,7 @@ Timescales:
            the distribution of eigenvalues and eigenvectors in Markovian state
            models for molecular dynamics." J. Chem. Phys. 126.24 (2007): 244101.
         """
-        if self.reversible_type is None:
-            raise NotImplementedError('reversible_type must be "mle" or "transpose"')
-
         u, lv, rv = self._get_eigensystem()
-
         sigma_eigs = self.uncertainty_eigenvalues()
-        sigma_ts = np.zeros_like(sigma_eigs)
-
-        for k in range(len(sigma_eigs)-1):
-            sigma_ts[k] = sigma_eigs[k] / (u[k] * np.log(u[k])**2)
-        return sigma_ts[1:]   # drop the first eigenvalue
+        sigma_ts = sigma_eigs / (u * np.log(u)**2)
+        return sigma_ts[1:]  # drop the first eigenvalue

--- a/msmbuilder/msm/msm.py
+++ b/msmbuilder/msm/msm.py
@@ -627,3 +627,62 @@ Timescales:
             selected_pairs_by_state.append([pairs[random.choice(len(pairs))] for i in range(n_samples)])
 
         return np.array(selected_pairs_by_state)
+
+    def uncertainty_eigenvalues(self):
+        """Estimate of the element-wise asymptotic standard deviation
+        in the model eigenvalues.
+
+        Returns
+        -------
+        sigma_eigs : np.array, shape=(n_timescales+1,)
+            The estimated symptotic standard deviation in the eigenvalues.
+
+        References
+        ----------
+        .. [1] Hinrichs, Nina Singhal, and Vijay S. Pande. "Calculation of
+           the distribution of eigenvalues and eigenvectors in Markovian state
+           models for molecular dynamics." J. Chem. Phys. 126.24 (2007): 244101.
+        """
+
+        n_timescales = min(self.n_timescales, self.n_states_ - 1)
+        if n_timescales is None:
+            n_timescales = self.n_states_ - 1
+        u, lv, rv = self._get_eigensystem()
+
+        sigma2 = np.zeros(n_timescales + 1)
+        for k in range(n_timescales + 1):
+            dLambda_dT = np.outer(lv[:, k], rv[:, k])
+            for i in range(self.n_states_):
+                ui = self.countsmat_[:, i]
+                wi = np.sum(ui)
+                covariance = wi*np.diag(ui) - np.outer(ui, ui)
+                sigma2[k] += dLambda_dT[i].dot(covariance).dot(dLambda_dT[i]) / (wi**2*(wi+1))
+        return np.sqrt(sigma2)
+
+    def uncertainty_timescales(self):
+        """Estimate of the element-wise asymptotic standard deviation
+        in the model implied timescales.
+
+        Returns
+        -------
+        sigma_timescales : np.array, shape=(n_timescales,)
+            The estimated symptotic standard deviation in the implied
+            timescales.
+
+        References
+        ----------
+        .. [1] Hinrichs, Nina Singhal, and Vijay S. Pande. "Calculation of
+           the distribution of eigenvalues and eigenvectors in Markovian state
+           models for molecular dynamics." J. Chem. Phys. 126.24 (2007): 244101.
+        """
+
+        n_timescales = min(self.n_timescales, self.n_states_ - 1)
+        if n_timescales is None:
+            n_timescales = self.n_states_ - 1
+        u, lv, rv = self._get_eigensystem()
+
+        sigma2 = np.zeros(n_timescales + 1)
+        sigma2_eigs = self.uncertainty_eigenvalues()
+        for k in range(n_timescales + 1):
+            sigma2[k] = sigma2_eigs[k] / (u[k] * np.log(u[k])**2)
+        return sigma2[1:]

--- a/msmbuilder/tests/test_msm_uncertainty.py
+++ b/msmbuilder/tests/test_msm_uncertainty.py
@@ -45,6 +45,7 @@ def test_0():
         analytic = np.outer(lv[:, k], rv[:, k])
         np.testing.assert_almost_equal(dLambda_dP_numeric[k], analytic, decimal=5)
 
+
 def test_1():
     X = load_doublewell(random_state=0)['trajectories']
     for i in range(10):

--- a/msmbuilder/tests/test_msm_uncertainty.py
+++ b/msmbuilder/tests/test_msm_uncertainty.py
@@ -12,8 +12,9 @@ from msmbuilder.msm.core import _solve_msm_eigensystem
 def test_0():
     random = np.random.RandomState(0)
     h = 1e-7
-    X = [[1, 1, 1, 1, 0, 0, 0, 0, 0, 2,2,2,2,2,1, 1, 1, 1 ,1, 0, 0, 0, 0, 1, 1, 1, 1, 1]]
-    model = MarkovStateModel().fit(X)
+    X = load_doublewell(random_state=0)['trajectories']
+    Y = NDGrid(n_bins_per_feature=10).fit_transform(X)
+    model = MarkovStateModel(verbose=False).fit(Y)
     n = model.n_states_
 
     u, lv, rv = _solve_msm_eigensystem(model.transmat_, n)
@@ -25,12 +26,11 @@ def test_0():
                 H = np.zeros((n, n))
                 H[i, j] = h
                 w = -np.sort(-eigvals(model.transmat_ + H))
-                dLambda_dP_numeric[i, j] = (w[k] - model.eigenvalues_[k]) / h
+                dLambda_dP_numeric[i, j] = np.real((w[k] - model.eigenvalues_[k]) / h)
 
 
-        dLambda_dP_numeric
         analytic = np.outer(lv[:, k], rv[:, k])
-        np.testing.assert_almost_equal(dLambda_dP_numeric, analytic)
+        np.testing.assert_almost_equal(dLambda_dP_numeric, analytic, decimal=5)
 
 def test_1():
     X = load_doublewell(random_state=0)['trajectories']

--- a/msmbuilder/tests/test_msm_uncertainty.py
+++ b/msmbuilder/tests/test_msm_uncertainty.py
@@ -1,0 +1,45 @@
+from __future__ import print_function
+import numpy as np
+import scipy.linalg
+from scipy.linalg import eigvals
+from scipy.optimize import approx_fprime
+from msmbuilder.cluster import NDGrid
+from msmbuilder.example_datasets import load_doublewell
+from msmbuilder.msm import MarkovStateModel, ContinuousTimeMSM
+from msmbuilder.msm.core import _solve_msm_eigensystem
+
+
+def test_0():
+    random = np.random.RandomState(0)
+    h = 1e-7
+    X = [[1, 1, 1, 1, 0, 0, 0, 0, 0, 2,2,2,2,2,1, 1, 1, 1 ,1, 0, 0, 0, 0, 1, 1, 1, 1, 1]]
+    model = MarkovStateModel().fit(X)
+    n = model.n_states_
+
+    u, lv, rv = _solve_msm_eigensystem(model.transmat_, n)
+
+    for k in range(n):
+        dLambda_dP_numeric = np.zeros((n, n))
+        for i in range(n):
+            for j in range(n):
+                H = np.zeros((n, n))
+                H[i, j] = h
+                w = -np.sort(-eigvals(model.transmat_ + H))
+                dLambda_dP_numeric[i, j] = (w[k] - model.eigenvalues_[k]) / h
+
+
+        dLambda_dP_numeric
+        analytic = np.outer(lv[:, k], rv[:, k])
+        np.testing.assert_almost_equal(dLambda_dP_numeric, analytic)
+
+def test_1():
+    X = load_doublewell(random_state=0)['trajectories']
+    for i in range(10):
+        Y = NDGrid(n_bins_per_feature=10).fit_transform([X[i]])
+        model = MarkovStateModel(verbose=False).fit(Y)
+        model2 = ContinuousTimeMSM().fit(Y)
+
+        print(model.uncertainty_timescales())
+        print(model2.uncertainty_timescales())
+        print()
+

--- a/msmbuilder/tests/test_msm_uncertainty.py
+++ b/msmbuilder/tests/test_msm_uncertainty.py
@@ -10,8 +10,12 @@ from msmbuilder.msm.core import _solve_msm_eigensystem
 
 
 def test_0():
-    random = np.random.RandomState(0)
-    h = 1e-7
+    # Verify that the partial derivatives of the ith eigenvalue of the
+    # transition matrix with respect to the entries of the transition matrix
+    # is given by the outer product of the left and right eigenvectors
+    # corresponding to that eigenvalue.
+    # \frac{\partial \lambda_k}{\partial T_{ij}} = U_{i,k} V_{j,k}
+
     X = load_doublewell(random_state=0)['trajectories']
     Y = NDGrid(n_bins_per_feature=10).fit_transform(X)
     model = MarkovStateModel(verbose=False).fit(Y)
@@ -19,18 +23,27 @@ def test_0():
 
     u, lv, rv = _solve_msm_eigensystem(model.transmat_, n)
 
+    # first, compute forward difference numerical derivatives
+    h = 1e-7
+    dLambda_dP_numeric = np.zeros((n, n, n))
+    # dLambda_dP_numeric[eigenvalue_index, i, j]
+    for i in range(n):
+        for j in range(n):
+            # perturb the (i,j) entry of transmat
+            H = np.zeros((n, n))
+            H[i, j] = h
+            u_perturbed = sorted(np.real(eigvals(model.transmat_ + H)), reverse=True)
+
+            # compute the forward different approx. derivative of each
+            # of the eigenvalues
+            for k in range(n):
+                # sort the eigenvalues of the perturbed matrix in descending
+                # order, to be consistent w/ _solve_msm_eigensystem
+                dLambda_dP_numeric[k, i, j] = (u_perturbed[k] - u[k]) / h
+
     for k in range(n):
-        dLambda_dP_numeric = np.zeros((n, n))
-        for i in range(n):
-            for j in range(n):
-                H = np.zeros((n, n))
-                H[i, j] = h
-                w = -np.sort(-eigvals(model.transmat_ + H))
-                dLambda_dP_numeric[i, j] = np.real((w[k] - model.eigenvalues_[k]) / h)
-
-
         analytic = np.outer(lv[:, k], rv[:, k])
-        np.testing.assert_almost_equal(dLambda_dP_numeric, analytic, decimal=5)
+        np.testing.assert_almost_equal(dLambda_dP_numeric[k], analytic, decimal=5)
 
 def test_1():
     X = load_doublewell(random_state=0)['trajectories']

--- a/msmbuilder/tests/test_msm_uncertainty.py
+++ b/msmbuilder/tests/test_msm_uncertainty.py
@@ -3,10 +3,12 @@ import numpy as np
 import scipy.linalg
 from scipy.linalg import eigvals
 from scipy.optimize import approx_fprime
+import scipy.stats
 from msmbuilder.cluster import NDGrid
 from msmbuilder.example_datasets import load_doublewell
 from msmbuilder.msm import MarkovStateModel, ContinuousTimeMSM
 from msmbuilder.msm.core import _solve_msm_eigensystem
+import matplotlib.pyplot as pp
 
 
 def test_0():
@@ -48,12 +50,61 @@ def test_0():
 
 def test_1():
     X = load_doublewell(random_state=0)['trajectories']
-    for i in range(10):
+    for i in range(3):
         Y = NDGrid(n_bins_per_feature=10).fit_transform([X[i]])
-        model = MarkovStateModel(verbose=False).fit(Y)
+        model1 = MarkovStateModel(verbose=False).fit(Y)
         model2 = ContinuousTimeMSM().fit(Y)
 
-        print(model.uncertainty_timescales())
+        print('MSM uncertainty timescales:')
+        print(model1.uncertainty_timescales())
+        print('ContinuousTimeMSM uncertainty timescales:')
         print(model2.uncertainty_timescales())
         print()
 
+
+def test_2():
+    model = MarkovStateModel(verbose=False)
+    C = np.array([
+        [4380, 153,  15,   2,    0,    0],
+        [211,  4788, 1,    0,    0,    0],
+        [169,  1,    4604, 226,  0,    0],
+        [3,    13,   158,  4823, 3,    0],
+        [0,    0,    0,    4,    4978, 18],
+        [7,    5,    0,    0,    62,   4926]], dtype=float)
+    C = C + 1.0 / 6.0
+    model.n_states_ = C.shape[0]
+    model.countsmat_ = C
+    model.transmat_, model.populations_ = model._fit_mle(C)
+
+    n_trials = 5000
+    random = np.random.RandomState(0)
+    all_timescales = np.zeros((n_trials, model.n_states_ - 1))
+    all_eigenvalues = np.zeros((n_trials, model.n_states_))
+    for i in range(n_trials):
+        T = np.vstack([random.dirichlet(C[i]) for i in range(C.shape[0])])
+        u = _solve_msm_eigensystem(T, k=6)[0]
+        all_eigenvalues[i] = u
+        all_timescales[i] = -1 / np.log(u[1:])
+
+    pp.figure(figsize=(12, 8))
+    for i in range(3):
+        pp.subplot(2,3,i+1)
+        pp.title('Timescale %d' % i)
+        kde = scipy.stats.gaussian_kde(all_timescales[:, i])
+        xx = np.linspace(all_timescales[:,i].min(), all_timescales[:,i].max())
+        r = scipy.stats.norm(loc=model.timescales_[i], scale=model.uncertainty_timescales()[i])
+        pp.plot(xx, kde.evaluate(xx), c='r', label='Samples')
+        pp.plot(xx, r.pdf(xx), c='b', label='Analytic')
+
+    for i in range(1, 4):
+        pp.subplot(2,3,3+i)
+        pp.title('Eigenvalue %d' % i)
+        kde = scipy.stats.gaussian_kde(all_eigenvalues[:, i])
+        xx = np.linspace(all_eigenvalues[:,i].min(), all_eigenvalues[:,i].max())
+        r = scipy.stats.norm(loc=model.eigenvalues_[i], scale=model.uncertainty_eigenvalues()[i])
+        pp.plot(xx, kde.evaluate(xx), c='r', label='Samples')
+        pp.plot(xx, r.pdf(xx), c='b', label='Analytic')
+
+    pp.tight_layout()
+    pp.legend(loc=4)
+    pp.savefig('test_msm_uncertainty_plots.png')


### PR DESCRIPTION
The whole appendix of this paper [1] is supposed to show an algorithm for calculating the partial derivatives of the eigenvalues of the transition matrix w.r.t. the transition matrix elements, `\frac{\partial \lambda_k}{\partial T_{ij}`, but I don't think authors didn't really do it the right way. I'm sure the way its written in the paper is correct, but they skipped the _much_ simpler solution, which is just `\frac{\partial \lambda_k}{\partial T_{ij} = U_{ik} V_{jk}`, where U and V are the matrices with the left and right eigenvectors respectively as columns. I guess this is only true of the the transition matrix satisfies detailed balance, but I think that's the situation of interest.

[1] [Calculation of the distribution of eigenvalues and eigenvectors in Markovian state models for molecular dynamics](http://scitation.aip.org/content/aip/journal/jcp/126/24/10.1063/1.2740261)