### PR TITLE
Add ergodic trimming in ContinuousTimeMSM

### DIFF
--- a/msmbuilder/msm/core.py
+++ b/msmbuilder/msm/core.py
@@ -13,8 +13,7 @@ from sklearn.base import TransformerMixin
 
 __all__ = [
     '_MappingTransformMixin', '_dict_compose', '_strongly_connected_subgraph',
-    '_transition_counts',
-    '_solve_msm_eigensystem',
+    '_transition_counts', '_normalize_eigensystem', '_solve_msm_eigensystem',
 ]
 
 
@@ -304,7 +303,7 @@ def _transition_counts(sequences, lag_time=1, sliding_window=True):
 
     counts = np.zeros((n_states, n_states), dtype=float)
     _transitions = []
-    
+
     for y in sequences:
         y = np.asarray(y)
         from_states = y[: -lag_time: 1]

--- a/msmbuilder/msm/ratematrix.py
+++ b/msmbuilder/msm/ratematrix.py
@@ -14,7 +14,7 @@ from ..base import BaseEstimator
 from ..utils import list_of_1d, printoptions, experimental
 from . import _ratematrix
 from ._markovstatemodel import _transmat_mle_prinz
-from .core import (_MappingTransformMixin, _transition_counts, _dict_compose
+from .core import (_MappingTransformMixin, _transition_counts, _dict_compose,
                    _normalize_eigensystem, _strongly_connected_subgraph)
 
 

--- a/msmbuilder/tests/test_ratematrix.py
+++ b/msmbuilder/tests/test_ratematrix.py
@@ -13,6 +13,7 @@ except ImportError:
 
 from msmbuilder.msm import _ratematrix
 from msmbuilder.msm import ContinuousTimeMSM, MarkovStateModel
+from msmbuilder.example_datasets import MullerPotential
 from msmbuilder.example_datasets import load_doublewell
 from msmbuilder.cluster import NDGrid
 random = np.random.RandomState(0)
@@ -279,7 +280,6 @@ def test_score_1():
     np.testing.assert_approx_equal(model.score(seqs), model.score_)
 
 
-
 def test_optimize_1():
     n = 100
     grid = NDGrid(n_bins_per_feature=n, min=-np.pi, max=np.pi)
@@ -291,8 +291,23 @@ def test_optimize_1():
     x = x-x[0]
     cross = np.min(np.where(n==n[-1])[0])
 
-    #import matplotlib.pyplot as pp
-    #pp.plot(x[cross], y[cross], 'kx')
-    #pp.axvline(x[cross], c='k')
-    #pp.plot(x, y)
-    #pp.show()
+
+def test_score_2():
+    from msmbuilder.example_datasets.muller import MULLER_PARAMETERS as PARAMS
+    ds = MullerPotential(random_state=0).get()['trajectories']
+    cluster = NDGrid(n_bins_per_feature=6,
+          min=[PARAMS['MIN_X'], PARAMS['MIN_Y']],
+          max=[PARAMS['MAX_X'], PARAMS['MAX_Y']])
+    assignments = cluster.fit_transform(ds)
+    test_indices = [5, 0, 4, 1, 2]
+    train_indices = [3, 6, 7, 8, 9]
+    model = ContinuousTimeMSM(lag_time=3, ftol=1e-8, n_timescales=1, sliding_window=True)
+    # model = MarkovStateModel(lag_time=3, verbose=False, n_timescales=2)
+
+    model.fit([assignments[i] for i in train_indices])
+    print(model.score_)
+    print(model.score([assignments[i] for i in test_indices]))
+
+    #
+    # model.fit([assignments[i] for i in test_indices])
+    # print(model.score([assignments[i] for i in test_indices]))

--- a/msmbuilder/tests/test_ratematrix.py
+++ b/msmbuilder/tests/test_ratematrix.py
@@ -301,13 +301,11 @@ def test_score_2():
     assignments = cluster.fit_transform(ds)
     test_indices = [5, 0, 4, 1, 2]
     train_indices = [3, 6, 7, 8, 9]
-    model = ContinuousTimeMSM(lag_time=3, ftol=1e-8, n_timescales=1, sliding_window=True)
-    # model = MarkovStateModel(lag_time=3, verbose=False, n_timescales=2)
 
+    model = ContinuousTimeMSM(lag_time=3, ftol=1e-8, n_timescales=1)
     model.fit([assignments[i] for i in train_indices])
-    print(model.score_)
-    print(model.score([assignments[i] for i in test_indices]))
+    test = model.score([assignments[i] for i in test_indices])
+    train = model.score_
+    assert 0 >= test >= -1
+    assert 0 >= train >= -1
 
-    #
-    # model.fit([assignments[i] for i in test_indices])
-    # print(model.score([assignments[i] for i in test_indices]))


### PR DESCRIPTION
I was getting some very odd results with GMRQ, where the test scores seemed sort of unstable. For example, I'd have a training set score of ~ -0.1, and over randomized shuffle splits, my test scores would be ~ -0.2, -0.2, -0.3, -100. I tracked down one of the erroneous shuffle-splits, and made it a test: `test_score_2`. The issue is related to zeros in the count matrix. Adding ergodic trimming (matching the behavior of `MSM`) seems to fix it up.