### PR TITLE
possible fix for #458 there are probably other ways to do this too

### DIFF
--- a/msmbuilder/dataset.py
+++ b/msmbuilder/dataset.py
@@ -173,7 +173,7 @@ class _BaseDataset(Sequence):
         return self.set(i, x)
 
     def __iter__(self):
-        for key in self.keys():
+        for key in sorted(self.keys(), key=_keynat):
             yield self.get(key)
 
     def keys(self):


### PR DESCRIPTION
We can either require that the implementation of the Datasets sorts the keys correctly, or we can sort it in the _BaseDataset class. 

Does anyone have a preference? Are there cases, where the sorted command in the _BaseDataset will not work?