### PR TITLE
Fix sort order

### DIFF
--- a/msmbuilder/dataset.py
+++ b/msmbuilder/dataset.py
@@ -83,6 +83,8 @@ def dataset(path, mode='r', fmt=None, verbose=False, **kwargs):
 
 
 def _guess_format(path):
+    """Guess the format of a dataset based on its filename / filenames.
+    """
     if isinstance(path, (list, tuple)):
         fmt = _guess_format(path[0])
         err = "Only the union of 'dir-npy' and 'hdf5' formats is supported"
@@ -177,6 +179,8 @@ class _BaseDataset(Sequence):
             yield self.get(key)
 
     def keys(self):
+        # keys()[i], get(i) and set(i, x) should all follow
+        # the same ordering convention for the indices / items.
         raise NotImplementedError('implemeneted in subclass')
 
     def get(self, i):
@@ -306,7 +310,8 @@ class HDF5Dataset(_BaseDataset):
         return self._handle.get_node('/', self._ITEM_FORMAT % i)[:]
 
     def keys(self):
-        for node in self._handle.iter_nodes('/'):
+        nodes = self._handle.list_nodes('/')
+        for node in sorted(nodes, key=lambda x: _keynat(x.name)):
             match = self._ITEM_RE.match(node.name)
             if match:
                 yield int(match.group(1))

--- a/msmbuilder/tests/test_dataset.py
+++ b/msmbuilder/tests/test_dataset.py
@@ -6,7 +6,7 @@ from six.moves import cPickle
 
 import numpy as np
 from nose.tools import assert_raises
-from msmbuilder.dataset import dataset
+from msmbuilder.dataset import dataset, _keynat, NumpyDirDataset
 from mdtraj.testing import get_fn
 from sklearn.externals.joblib import Parallel, delayed
 
@@ -212,6 +212,7 @@ def test_union_2():
         mds_out = mds.create_derived('derived', fmt='dir-npy')
         assert len(mds_out.provenance.split('\n')) > 0
 
+
 def test_union_3():
     with tempdir():
         # This doesn't work with py2.6
@@ -224,3 +225,15 @@ def test_union_3():
 
         with assert_raises(ValueError):
             mds = dataset(['ds1', 'ds2'])
+
+def test_order_1():
+    with tempdir():
+        with dataset('ds1.h5', 'w', 'hdf5') as ds1:
+            for i in range(20):
+                ds1[i] = np.random.randn(10)
+            assert list(ds1.keys()) == list(range(20))
+
+        with dataset('ds1/', 'w', 'dir-npy') as ds1:
+            for i in range(20):
+                ds1[i] = np.random.randn(10)
+            assert list(ds1.keys()) == list(range(20))


### PR DESCRIPTION
This test now passes. It did not pass before.

```
def test_order_1():
    with tempdir():
        with dataset('ds1.h5', 'w', 'hdf5') as ds1:
            for i in range(20):
                ds1[i] = np.random.randn(10)
            assert list(ds1.keys()) == list(range(20))

        with dataset('ds1/', 'w', 'dir-npy') as ds1:
            for i in range(20):
                ds1[i] = np.random.randn(10)
            assert list(ds1.keys()) == list(range(20))
```

cc #458, #459.