### PR TITLE
[ENH] ContinuousTimeMSM. Revert #466, use scipy.linalg.logm

### DIFF
--- a/msmbuilder/msm/_ratematrix_support.pyx
+++ b/msmbuilder/msm/_ratematrix_support.pyx
@@ -1,39 +1,5 @@
 # This file is designed to be included by _ratematrix.pyx
 
-cpdef logm(const double[:, ::1] A, double[::1] pi, double t=1.0):
-    r"""Compute the principle logarithm of a reversible matrix.
-
-    If :math:`A = exp(tK)`, this expression solves for K given A and t.
-
-    If :math:`A = V diag(\lambda) U^T`, the matrix log is defined as
-    :math:`log(A) = V \log(diag((\lambda)) U^T`, where log(diag(\lambda))
-    is computed by applying the scalar log to each entry on the diagonal.
-    Negative eigenvalues of A are simply truncated to zero.
-    """
-    cdef npy_intp i
-    cdef npy_intp n = len(pi)
-    cdef double[:, ::1] temp, out
-
-    if not (A.shape[0] == A.shape[1] == n):
-        raise ValueError()
-    temp = np.zeros((n, n))
-    out = np.zeros((n, n))
-
-    w, U, V = eig_K(A, len(A), pi)
-    for i in range(n):
-        if w[i] > 0:
-            w[i] = log(w[i]) / t
-        else:
-            w[i] = 0
-
-    for i in range(n):
-        for j in range(n):
-            temp[i, j] = V[i,j] * w[j]
-
-    cdgemm_NT(temp, U, out)
-    return out
-
-
 cpdef eig_K(const double[:, ::1] A, npy_intp n, double[::1] pi=None, which='K'):
     r"""eig_K(A, n, pi=None, which='K')
 

--- a/msmbuilder/msm/ratematrix.py
+++ b/msmbuilder/msm/ratematrix.py
@@ -317,7 +317,7 @@ class ContinuousTimeMSM(BaseEstimator, _MappingTransformMixin):
         """Generate an initial guess for \theta.
         """
         transmat, pi = _transmat_mle_prinz(countsmat + self.prior_counts)
-        K = _ratematrix.logm(transmat, pi, self.lag_time)
+        K = np.real(scipy.linalg.logm(transmat)) / self.lag_time
         S = np.multiply(np.sqrt(np.outer(pi, 1/pi)), K)
 
         sflat = np.maximum(S[np.triu_indices_from(countsmat, k=1)], 1e-10)

--- a/msmbuilder/tests/test_ratematrix.py
+++ b/msmbuilder/tests/test_ratematrix.py
@@ -16,7 +16,6 @@ from msmbuilder.msm import ContinuousTimeMSM, MarkovStateModel
 from msmbuilder.example_datasets import MullerPotential
 from msmbuilder.example_datasets import load_doublewell
 from msmbuilder.cluster import NDGrid
-from msmbuilder.msm._markovstatemodel import _transmat_mle_prinz
 random = np.random.RandomState(0)
 
 
@@ -33,17 +32,6 @@ def sparse_exptheta(n):
     exp_sp = exptheta[np.nonzero(exptheta)]
     inds_sp = np.nonzero(exptheta)[0]
     return exp_d, exp_sp, inds_sp
-
-
-def test_logm():
-    C = random.randint(5, size=(5,5)).astype(np.double)
-    C += 20 * np.eye(*C.shape)
-    T, pi = _transmat_mle_prinz(C)
-
-    K1 = np.asarray(_ratematrix.logm(T, pi))
-    K2 = scipy.linalg.logm(T)
-
-    np.testing.assert_array_almost_equal(K1, K2)
 
 
 def test_build_ratemat_1():
@@ -344,20 +332,4 @@ def test_score_3():
     model.fit(train_data)
     train = model.score_
     test = model.score(test_data)
-    # test = model.score(train_data)
     print(train, test)
-
-
-def test_fit_3():
-    import warnings
-    warnings.simplefilter('ignore')
-    from msmbuilder.example_datasets.muller import MULLER_PARAMETERS as PARAMS
-
-    cluster = NDGrid(n_bins_per_feature=6,
-          min=[PARAMS['MIN_X'], PARAMS['MIN_Y']],
-          max=[PARAMS['MAX_X'], PARAMS['MAX_Y']])
-
-    ds = MullerPotential(random_state=0).get()['trajectories']
-    assignments = cluster.fit_transform(ds)
-    model = ContinuousTimeMSM(lag_time=100, ftol=0.0001)
-    model.fit(assignments)


### PR DESCRIPTION
Empirically, I'm getting much better convergence doing initialization with `np.real(scipy.linalg.logm(transmat)) / self.lag_time` than the custom routine I committed in #466, especially on test set performance.