### PR TITLE
remove value error for trajectories that are too short in tICA._fit

### DIFF
--- a/msmbuilder/decomposition/tica.py
+++ b/msmbuilder/decomposition/tica.py
@@ -14,6 +14,7 @@ from ..base import BaseEstimator
 from ..utils import check_iter_of_sequences
 from sklearn.base import TransformerMixin
 from sklearn.utils import array2d
+import warnings
 
 __all__ = ['tICA']
 
@@ -363,6 +364,7 @@ class tICA(BaseEstimator, TransformerMixin):
 
         # We don't need t scream and shout here. Just ignore this data.
         if not len(X) > self.lag_time:
+            warnings.warn("length of data (%d) is too short for the lag time (%d)" % (len(X), self.lag_time))
             return
 
         self.n_observations_ += X.shape[0]

--- a/msmbuilder/decomposition/tica.py
+++ b/msmbuilder/decomposition/tica.py
@@ -360,9 +360,10 @@ class tICA(BaseEstimator, TransformerMixin):
     def _fit(self, X):
         X = np.asarray(array2d(X), dtype=np.float64)
         self._initialize(X.shape[1])
+
+        # We don't need t scream and shout here. Just ignore this data.
         if not len(X) > self.lag_time:
-            raise ValueError('First dimension must be longer than '
-                'lag_time=%d. X has shape (%d, %d)' % ((self.lag_time,) + X.shape))
+            return
 
         self.n_observations_ += X.shape[0]
         self.n_sequences_ += 1


### PR DESCRIPTION
@sryckbos was using tICA with osprey on some FAH data. Some trajectories are too short depending on the correlation lag time, but the code throws an error instead of failing silently.

So, tICA._fit just silently ignores the data. Alternatively, we could print a warning, but throwing an exception is the wrong behavior.
