### PR TITLE
Fix ratematrix loglikeilhood bug

### DIFF
--- a/msmbuilder/msm/ratematrix.py
+++ b/msmbuilder/msm/ratematrix.py
@@ -200,7 +200,7 @@ class ContinuousTimeMSM(BaseEstimator, _MappingTransformMixin):
 
         def objective(theta):
             f, g = _ratematrix.loglikelihood(theta, countsmat, lag_time)
-            loglikelihood.append(f)
+            loglikelihoods.append(f)
 
             if not np.isfinite(f):
                 f = np.nan


### PR DESCRIPTION
Fixes this bug:

```
pyflakes ratematrix.py 
ratematrix.py:203: undefined name 'loglikelihood'
```