### PR TITLE
rate.fit() should return self to work in pipeline.

### DIFF
--- a/msmbuilder/msm/ratematrix.py
+++ b/msmbuilder/msm/ratematrix.py
@@ -141,8 +141,7 @@ class ContinuousTimeMSM(BaseEstimator, _MappingTransformMixin):
     @experimental('ContinuousTimeMSM')
     def fit(self, sequences, y=None):
         self._build_counts(sequences)
-        self._fit()
-        return self
+        return self._fit()
 
     def _fit(self):
         result, loglikelihoods = self._optimize()

--- a/msmbuilder/msm/ratematrix.py
+++ b/msmbuilder/msm/ratematrix.py
@@ -142,6 +142,7 @@ class ContinuousTimeMSM(BaseEstimator, _MappingTransformMixin):
     def fit(self, sequences, y=None):
         self._build_counts(sequences)
         self._fit()
+        return self
 
     def _fit(self):
         result, loglikelihoods = self._optimize()


### PR DESCRIPTION
Fixes the following:

```
import glob
import mdtraj as md
from msmbuilder import example_datasets, cluster, msm, featurizer, lumping
from sklearn.pipeline import make_pipeline



dataset = example_datasets.alanine_dipeptide.fetch_alanine_dipeptide()  # From Figshare!
trajectories = dataset["trajectories"]  # List of MDTraj Trajectory Objects

n_states = 10
n_macro = 5

clusterer = cluster.MiniBatchKMedoids(n_clusters=n_states, metric="rmsd")
rate_model = msm.ContinuousTimeMSM()
msm_model = msm.MarkovStateModel()
pcca = lumping.PCCAPlus(n_macrostates=n_macro)

pipeline = make_pipeline(clusterer, msm_model, pcca)
pipeline.fit(trajectories)

pipeline = make_pipeline(clusterer, rate_model, pcca)
pipeline.fit(trajectories)
```

```
In [16]: pipeline.fit(trajectories)
/home/kyleb/opt/lib/python2.7/site-packages/sklearn/base.py:426: ExperimentalWarning: 
"""""""""""""""""""""""""""""""""""""""""""""""""""""""""
Warning: 'ContinuousTimeMSM' is in an experimental state.
"""""""""""""""""""""""""""""""""""""""""""""""""""""""""
  return self.fit(X, **fit_params).transform(X)
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-16-2a53ae70d9bb> in <module>()
----> 1 pipeline.fit(trajectories)

/home/kyleb/opt/lib/python2.7/site-packages/sklearn/pipeline.pyc in fit(self, X, y, **fit_params)
    127         data, then fit the transformed data using the final estimator.
    128         """
--> 129         Xt, fit_params = self._pre_transform(X, y, **fit_params)
    130         self.steps[-1][-1].fit(Xt, y, **fit_params)
    131         return self

/home/kyleb/opt/lib/python2.7/site-packages/sklearn/pipeline.pyc in _pre_transform(self, X, y, **fit_params)
    117         for name, transform in self.steps[:-1]:
    118             if hasattr(transform, "fit_transform"):
--> 119                 Xt = transform.fit_transform(Xt, y, **fit_params_steps[name])
    120             else:
    121                 Xt = transform.fit(Xt, y, **fit_params_steps[name]) \

/home/kyleb/opt/lib/python2.7/site-packages/sklearn/base.pyc in fit_transform(self, X, y, **fit_params)
    424         if y is None:
    425             # fit method of arity 1 (unsupervised transformation)
--> 426             return self.fit(X, **fit_params).transform(X)
    427         else:
    428             # fit method of arity 2 (supervised transformation)

AttributeError: 'NoneType' object has no attribute 'transform'
```