### PR TITLE
Moved changelog to end of docs

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -38,7 +38,6 @@ licensed under the GNU LGPL (v2.1 or later).
 
     background
     installation
-    changelog
     examples/index
     featurization
     cluster
@@ -52,6 +51,7 @@ licensed under the GNU LGPL (v2.1 or later).
     apipatterns
     plugins
     faq
+    changelog    
 
 .. raw:: html
 


### PR DESCRIPTION
One more question: does anyone know why "Frequently asked questions" somehow appears twice on the left-hand panel of "main doc pages"?