### PR TITLE
Make counts behave sensibly

### DIFF
--- a/msmbuilder/cmdline.py
+++ b/msmbuilder/cmdline.py
@@ -270,7 +270,7 @@ class NumpydocClassCommand(Command):
         for k, v in args.__dict__.items():
             # these are all of the specified options from the command line
             # some of them correspond to __init__ args for self.klass, and
-            # others are "extra" arguments that wern't part of klass
+            # others are "extra" arguments that weren't part of klass
 
             if k in init_args:
                 # put the ones for klass.__init__ in a dict
@@ -343,11 +343,19 @@ class NumpydocClassCommand(Command):
                 if 'bool' in typemap[arg]:
                     kwargs['action'] = FlagAction
 
-                basic_types = {'str': str, 'float': float, 'int': int}
-                for basic_type in basic_types:
-                    if basic_type in typemap[arg]:
-                        kwargs['type'] = basic_types[basic_type]
-                        break
+                if hasattr(cls, '_{}_type'.format(arg)):
+                    # If the docstring *contains* the word float or int,
+                    # parsing will fail for things not of that type
+                    # even if a custom loader will eventually be used.
+                    # Let's check for custom loaders here and set the type
+                    # to str.
+                    kwargs['type'] = str
+                else:
+                    basic_types = {'str': str, 'float': float, 'int': int}
+                    for basic_type in basic_types:
+                        if basic_type in typemap[arg]:
+                            kwargs['type'] = basic_types[basic_type]
+                            break
 
             group.add_argument('--{}'.format(arg), **kwargs)
 

--- a/msmbuilder/commands/fit.py
+++ b/msmbuilder/commands/fit.py
@@ -60,6 +60,12 @@ class MarkovStateModelCommand(FitCommand):
     _concrete = True
     _group = 'MSM'
 
+    def _ergodic_cutoff_type(self, erg):
+        if erg.lower() in ['on', 'off']:
+            return erg
+        else:
+            return float(erg)
+
 
 class BayesianMarkovStateModelCommand(FitCommand):
     klass = BayesianMarkovStateModel

--- a/msmbuilder/msm/core.py
+++ b/msmbuilder/msm/core.py
@@ -389,7 +389,7 @@ def _transition_counts(sequences, lag_time=1, sliding_window=True):
     lag_time : int
         The time (index) delay for the counts.
     sliding_window : bool
-        When lag_time > 1, considering *all*
+        When lag_time > 1, consider *all*
         ``N = lag_time`` strided sequences starting from index
          0, 1, 2, ..., ``lag_time - 1``. The total, raw counts will
          be divided by ``N``. When this is False, only start from index 0.

--- a/msmbuilder/msm/core.py
+++ b/msmbuilder/msm/core.py
@@ -478,11 +478,13 @@ def _transition_counts(sequences, lag_time=1, sliding_window=True):
         shape=(n_states, n_states))
     counts = counts + np.asarray(C.todense())
 
-    # The following condition isn't strictly necessary: if sliding window
-    # is false, this function is called recursively at the beginning with
-    # strided trajectories and lag_time = 1. Dividing by 1 is nothing.
-    if sliding_window:
-        counts /= float(lag_time)
+    # If sliding window is False, this function will be called recursively
+    # with strided trajectories and lag_time = 1, which gives the desired
+    # number of counts. If sliding window is True, the counts are divided
+    # by the "number of windows" (i.e. the lag_time). Count magnitudes
+    # will be comparable between sliding-window and non-sliding-window cases.
+    # If lag_time = 1, sliding_window makes no difference.
+    counts /= float(lag_time)
 
     return counts, mapping
 

--- a/msmbuilder/msm/msm.py
+++ b/msmbuilder/msm/msm.py
@@ -60,7 +60,8 @@ class MarkovStateModel(BaseEstimator, _MappingTransformMixin, _SampleMSMMixin):
         accessible from each other state via one or more paths involving edges
         with a number of observed directed counts greater than or equal to
         ``ergodic_cutoff``. Not that by setting ``ergodic_cutoff`` to 0 or
-        'off', this trimming is turned off.
+        'off', this trimming is turned off. Setting it to 'on' sets the
+        cutoff to the minimal possible count value.
     prior_counts : float, optional
         Add a number of "pseudo counts" to each entry in the counts matrix
         after ergodic trimming.  When prior_counts == 0 (default), the assigned

--- a/msmbuilder/msm/msm.py
+++ b/msmbuilder/msm/msm.py
@@ -54,7 +54,7 @@ class MarkovStateModel(BaseEstimator, _MappingTransformMixin, _SampleMSMMixin):
         solved by numerical optimization, and 'transpose'
         uses a more restrictive (but less computationally complex)
         direct symmetrization of the expected number of counts.
-    ergodic_cutoff : float, {'on', 'off'}, default='on'
+    ergodic_cutoff : float or {'on', 'off'}, default='on'
         Only the maximal strongly ergodic subgraph of the data is used to build
         an MSM. Ergodicity is determined by ensuring that each state is
         accessible from each other state via one or more paths involving edges

--- a/msmbuilder/msm/msm.py
+++ b/msmbuilder/msm/msm.py
@@ -59,7 +59,7 @@ class MarkovStateModel(BaseEstimator, _MappingTransformMixin, _SampleMSMMixin):
         an MSM. Ergodicity is determined by ensuring that each state is
         accessible from each other state via one or more paths involving edges
         with a number of observed directed counts greater than or equal to
-        ``ergodic_cutoff``. Not that by setting ``ergodic_cutoff`` to 0 or
+        ``ergodic_cutoff``. By setting ``ergodic_cutoff`` to 0 or
         'off', this trimming is turned off. Setting it to 'on' sets the
         cutoff to the minimal possible count value.
     prior_counts : float, optional

--- a/msmbuilder/msm/msm.py
+++ b/msmbuilder/msm/msm.py
@@ -54,24 +54,25 @@ class MarkovStateModel(BaseEstimator, _MappingTransformMixin, _SampleMSMMixin):
         solved by numerical optimization, and 'transpose'
         uses a more restrictive (but less computationally complex)
         direct symmetrization of the expected number of counts.
-    ergodic_cutoff : int, default=1
+    ergodic_cutoff : float, {'on', 'off'}, default='on'
         Only the maximal strongly ergodic subgraph of the data is used to build
         an MSM. Ergodicity is determined by ensuring that each state is
         accessible from each other state via one or more paths involving edges
         with a number of observed directed counts greater than or equal to
-        ``ergodic_cutoff``. Not that by setting ``ergodic_cutoff`` to 0, this
-        trimming is effectively turned off.
+        ``ergodic_cutoff``. Not that by setting ``ergodic_cutoff`` to 0 or
+        'off', this trimming is turned off.
     prior_counts : float, optional
-        Add a number of "pseudo counts" to each entry in the counts matrix.
-        When prior_counts == 0 (default), the assigned transition
-        probability between two states with no observed transitions will be
-        zero, whereas when prior_counts > 0, even this unobserved transitions
-        will be given nonzero probability.
+        Add a number of "pseudo counts" to each entry in the counts matrix
+        after ergodic trimming.  When prior_counts == 0 (default), the assigned
+        transition probability between two states with no observed transitions
+        will be zero, whereas when prior_counts > 0, even this unobserved
+        transitions will be given nonzero probability.
     sliding_window : bool, optional
         Count transitions using a window of length ``lag_time``, which is slid
-        along the sequences 1 unit at a time, yielding transitions which contain
-        more data but cannot be assumed to be statistically independent. Otherwise,
-        the sequences are simply subsampled at an interval of ``lag_time``.
+        along the sequences 1 unit at a time, yielding transitions which
+        contain more data but cannot be assumed to be statistically
+        independent. Otherwise, the sequences are simply subsampled at an
+        interval of ``lag_time``.
     verbose : bool
         Enable verbose printout
 
@@ -106,15 +107,22 @@ class MarkovStateModel(BaseEstimator, _MappingTransformMixin, _SampleMSMMixin):
     """
 
     def __init__(self, lag_time=1, n_timescales=10, reversible_type='mle',
-                 ergodic_cutoff=1, prior_counts=0, sliding_window=True,
+                 ergodic_cutoff='on', prior_counts=0, sliding_window=True,
                  verbose=True):
         self.reversible_type = reversible_type
-        self.ergodic_cutoff = ergodic_cutoff
         self.lag_time = lag_time
         self.n_timescales = n_timescales
         self.prior_counts = prior_counts
         self.sliding_window = sliding_window
         self.verbose = verbose
+        if isinstance(ergodic_cutoff, str) and ergodic_cutoff.lower() == 'on':
+            if sliding_window:
+                ergodic_cutoff = 1.0/lag_time
+            else:
+                ergodic_cutoff = 1.0
+        elif isinstance(ergodic_cutoff, str) and ergodic_cutoff.lower() == 'off':
+            ergodic_cutoff = 0.0
+        self.ergodic_cutoff = ergodic_cutoff
 
         # Keep track of whether to recalculate eigensystem
         self._is_dirty = True
@@ -157,11 +165,11 @@ class MarkovStateModel(BaseEstimator, _MappingTransformMixin, _SampleMSMMixin):
         raw_counts, mapping = _transition_counts(
             sequences, int(self.lag_time), sliding_window=self.sliding_window)
 
-        if self.ergodic_cutoff >= 1:
+        if self.ergodic_cutoff > 0:
             # step 2. restrict the counts to the maximal strongly ergodic
             # subgraph
             self.countsmat_, mapping2 = _strongly_connected_subgraph(
-                self.lag_time * raw_counts, self.ergodic_cutoff, self.verbose)
+                raw_counts, self.ergodic_cutoff, self.verbose)
             self.mapping_ = _dict_compose(mapping, mapping2)
         else:
             # no ergodic trimming.
@@ -191,11 +199,9 @@ class MarkovStateModel(BaseEstimator, _MappingTransformMixin, _SampleMSMMixin):
         return self
 
     def _fit_mle(self, counts):
-        if self.ergodic_cutoff < 1:
-            with warnings.catch_warnings(record=True):
-                warnings.simplefilter("always")
-                warnings.warn("reversible_type='mle' and ergodic_cutoff < 1 "
-                              "are not generally compatible")
+        if self.ergodic_cutoff <= 0 and self.prior_counts == 0:
+            warnings.warn("reversible_type='mle' and ergodic_cutoff <= 0 "
+                          "are not generally compatible")
 
         transmat, populations = _transmat_mle_prinz(
             counts + self.prior_counts)

--- a/msmbuilder/tests/test_msm.py
+++ b/msmbuilder/tests/test_msm.py
@@ -17,7 +17,7 @@ from msmbuilder.msm.core import _transition_counts
 from msmbuilder.msm import MarkovStateModel
 
 
-def test_1():
+def test_counts_1():
     # test counts matrix without trimming
     model = MarkovStateModel(reversible_type=None, ergodic_cutoff=0)
 
@@ -26,13 +26,29 @@ def test_1():
     eq(model.mapping_, {1: 0})
 
 
-def test_2():
+def test_counts_2():
     # test counts matrix with trimming
     model = MarkovStateModel(reversible_type=None, ergodic_cutoff=1)
 
     model.fit([[1, 1, 1, 1, 1, 1, 1, 1, 1, 2]])
     eq(model.mapping_, {1: 0})
     eq(model.countsmat_, np.array([[8]]))
+
+
+def test_counts_3():
+    # test counts matrix scaling
+    seq = [1] * 4 + [2] * 4 + [1] * 4
+
+    model1 = MarkovStateModel(reversible_type=None, lag_time=2,
+                              sliding_window=True).fit([seq])
+    model2 = MarkovStateModel(reversible_type=None, lag_time=2,
+                              sliding_window=False).fit([seq])
+    model3 = MarkovStateModel(reversible_type=None, lag_time=2,
+                              ergodic_cutoff='off').fit([seq])
+
+    eq(model1.countsmat_, model2.countsmat_)
+    eq(model1.countsmat_, model3.countsmat_)
+    eq(model2.countsmat_, model3.countsmat_)
 
 
 def test_3():


### PR DESCRIPTION
w.r.t. lag time, sliding window, and ergodic trimming

supercedes #532 and fixes #522 

Changes the behavior of `ergodic_cutoff` when `lag_time > 1` and `sliding_window == True`, but changes default behavior to be the same
