### PR TITLE
Add deprecation note to featurizer commandline

### DIFF
--- a/msmbuilder/commands/featurizer.py
+++ b/msmbuilder/commands/featurizer.py
@@ -27,7 +27,7 @@ class FeaturizerCommand(NumpydocClassCommand):
     out = argument(
         '--out', required=True, help="""Output path for featurized data.
         NOTE: THIS ARGUMENT WILL BE SWAPPED WITH --transformed IN MSMB 
-        3.4!!!
+        3.3!!!
         """, type=exttype('/'))
     stride = argument(
         '--stride', default=1, type=int,

--- a/msmbuilder/commands/featurizer.py
+++ b/msmbuilder/commands/featurizer.py
@@ -25,7 +25,10 @@ class FeaturizerCommand(NumpydocClassCommand):
         help='''Chunk size for loading trajectories using mdtraj.iterload''',
         default=10000, type=int)
     out = argument(
-        '--out', required=True, help='Output path', type=exttype('/'))
+        '--out', required=True, help="""Output path for featurized data.
+        NOTE: THIS ARGUMENT WILL BE SWAPPED WITH --transformed IN MSMB 
+        3.4!!!
+        """, type=exttype('/'))
     stride = argument(
         '--stride', default=1, type=int,
         help='Load only every stride-th frame')


### PR DESCRIPTION
```
Example Command
---------------
$ msmb DihedralFeaturizer --trj './trajectories/*.h5' \
    --out dihedrals-withchi --types phi psi chi1

optional arguments:
  -h, --help            show this help message and exit
  --chunk CHUNK         Chunk size for loading trajectories using
                        mdtraj.iterload (default: 10000)
  --out OUT             Output path for featurized data. NOTE: THIS ARGUMENT
                        WILL BE SWAPPED WITH --transformed IN MSMB 3.4!!!
  --stride STRIDE       Load only every stride-th frame (default: 1)
  --top TOP             Path to topology file matching the trajectories
  --trjs TRJS           Glob pattern for trajectories
```