### PR TITLE
MAINT: Fix script for updating version dropdown

### DIFF
--- a/devtools/ci/update-versions.py
+++ b/devtools/ci/update-versions.py
@@ -1,34 +1,47 @@
 from __future__ import print_function
 import os
-import boto
-from boto.s3.key import Key
-import msmbuilder.version
+import pip
+import json
+from tempfile import NamedTemporaryFile
+import subprocess
+from msmbuilder import version
+from six.moves.urllib.request import urlopen
+if not any(d.project_name == 's3cmd' for d in pip.get_installed_distributions()):
+    raise ImportError('The s3cmd pacakge is required. try $ pip install s3cmd')
 
-if msmbuilder.version.release:
-    # The secret key is available as a secure environment variable
-    # on travis-ci to push the build documentation to Amazon S3.
-    AWS_ACCESS_KEY_ID = os.environ['AWS_ACCESS_KEY_ID']
-    AWS_SECRET_ACCESS_KEY = os.environ['AWS_SECRET_ACCESS_KEY']
-    BUCKET_NAME = 'msmbuilder.org'
+URL = 'http://www.msmbuilder.org/versions.json'
+BUCKET_NAME = 'msmbuilder.org'
 
-    bucket_name = AWS_ACCESS_KEY_ID.lower() + '-' + BUCKET_NAME
-    conn = boto.connect_s3(AWS_ACCESS_KEY_ID,
-                AWS_SECRET_ACCESS_KEY)
-    bucket = conn.get_bucket(BUCKET_NAME)
-
-    root = 'doc/_build'
-
-    versions = json.load(urllib2.urlopen('http://www.msmbuilder.org/versions.json'))
-
-    # new release so all the others are now old
-    for i in xrange(len(versions)):
-        versions[i]['latest'] = False
-
-    versions.append({'version' : msmbuilder.version.short_version, 'latest' : True})
-
-    k = Key(bucket)
-    k.key = 'versions.json'
-    k.set_contents_from_string(json.dumps(versions))
-    
-else:
+if not version.release:
     print("This is not a release.")
+    exit(0)
+
+
+versions = json.load(urlopen(URL))
+
+# new release so all the others are now old
+for i in xrange(len(versions)):
+    versions[i]['latest'] = False
+
+versions.append({
+    'version': version.short_version,
+    'latest': True})
+
+# The secret key is available as a secure environment variable
+# on travis-ci to push the build documentation to Amazon S3.
+with NamedTemporaryFile('w') as config, NamedTemporaryFile('w') as v:
+    config.write('''[default]
+access_key = {AWS_ACCESS_KEY_ID}
+secret_key = {AWS_SECRET_ACCESS_KEY}
+'''.format(**os.environ))
+    json.dump(versions, v)
+    config.flush()
+    v.flush()
+
+    template = ('s3cmd --config {config} '
+                'put {vfile} s3://{bucket}/versions.json')
+    cmd = template.format(
+            config=config.name,
+            vfile=v.name,
+            bucket=BUCKET_NAME)
+    subprocess.call(cmd.split())


### PR DESCRIPTION
In the 3.2.0 release, the update of the versions.json file that controls the dropdown box didn't work because of an SSL issue in the boto s3 library. See https://travis-ci.org/msmbuilder/msmbuilder/jobs/58469800

For pushing the docs, we changed a while ago from using boto to using the `s3cmd` command line tool. This does the same for the logic that updates the version.json dropdown.