### PR TITLE
Optimizations to Gaussian HMM

### DIFF
--- a/msmbuilder/hmm/src/include/GaussianHMMFitter.h
+++ b/msmbuilder/hmm/src/include/GaussianHMMFitter.h
@@ -35,7 +35,7 @@ public:
     void do_mstep();
 private:
     void* owner;
-    std::vector<double> means, log_variances, inv_variances, obs, obs2;
+    std::vector<double> obs, obs2, a0, a1, a2;
 };
 
 } // namespace msmbuilder

--- a/msmbuilder/tests/test_ghmm.py
+++ b/msmbuilder/tests/test_ghmm.py
@@ -95,5 +95,6 @@ def test_3():
         for reversible_type in ('mle', 'transpose'):
             model = GaussianHMM(n_states=3, init_algo=init_algo, reversible_type=reversible_type, thresh=1e-4, n_iter=30)
             model.fit(X)
-            validate_timeseries(means, vars, transmat, model, 0.1, 0.08)
+            validate_timeseries(means, vars, transmat, model, 0.1, 0.1)
             assert abs(model.fit_logprob_[-1]-model.score(X)) < 0.5
+


### PR DESCRIPTION
This includes optimizations to computation and memory access in the two most expensive routines (compute_log_likelihood and accumulate_sufficient_statistics).  It also parallelizes most of the E-step across trajectories.

At this point, the majority of the time in the benchmark I'm using is spent in _init() and _do_mstep().  The former could presumably be made faster by changing the options for k-means, such as n_hotstart.  The most expensive part of the latter is the calls to linalg.solve().  I'm not sure if there's much I can do about that.