### PR TITLE
MAINT: Make exceptions in test_workflows more informative

### DIFF
--- a/msmbuilder/tests/test_workflows.py
+++ b/msmbuilder/tests/test_workflows.py
@@ -5,6 +5,33 @@ from pkg_resources import resource_filename
 from msmbuilder.tests.test_commands import tempdir
 
 
+class CalledProcessError(Exception):
+    def __init__(self, returncode, cmd, stdout=None, stderr=None):
+         self.returncode = returncode
+         self.cmd = cmd
+         self.stdout = stdout
+         self.stderr = stderr
+
+    def __str__(self):
+        return ("Command '%s' returned non-zero exit status %d.\n"
+                "\n==== stdout ====\n%s\n==== stderr ====\n%s\n") % (self.cmd, self.returncode,
+                                                 self.stdout, self.stderr)
+
+
+def check_call(cmd):
+    process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    try:
+        stdout, stderr = process.communicate()
+    except:
+        process.kill()
+        process.wait()
+        raise
+
+    retcode = process.poll()
+    if retcode:
+        raise CalledProcessError(retcode, cmd, stdout=stdout, stderr=stderr)
+
+
 def shell_lines(resource):
     fn = resource_filename('msmbuilder', resource)
     buf = ''
@@ -23,16 +50,16 @@ def shell_lines(resource):
 def test_workflow_1():
     with tempdir():
         for line in shell_lines('tests/workflows/test_1.sh'):
-            subprocess.check_call(line.split())
+            check_call(line.split())
 
 
 def test_workflow_2():
     with tempdir():
         for line in shell_lines('tests/workflows/test_2.sh'):
-            subprocess.check_call(line.split())
+            check_call(line.split())
 
 
 def test_workflow_3():
     with tempdir():
         for line in shell_lines('tests/workflows/test_3.sh'):
-            subprocess.check_call(line.split())
+            check_call(line.split())


### PR DESCRIPTION
Currently, when one of the tests fails in `test_worksflows`, the reported exception on the CI system doesn't capture the stdout/stderr, which makes it basically impossible to debug. It just shows "exit status 1". This captures the stdout and stderr, and puts them into the exception.