### PR TITLE
[WIP] Wrapping OneClassSVM

### DIFF
--- a/msmbuilder/outlier.py
+++ b/msmbuilder/outlier.py
@@ -1,0 +1,42 @@
+import numpy as np
+from .cluster import MultiSequenceClusterMixin, BaseEstimator
+from sklearn.svm import OneClassSVM
+
+class OneClassSVMTrimmer(MultiSequenceClusterMixin, OneClassSVM, BaseEstimator):
+    def partial_transform(self, traj):
+        """Transform a single sequence based on outlier detection.
+
+        Parameters
+        ----------
+        traj : sequence np.ndarray
+            A time series sequence
+
+        Returns
+        -------
+        trajout : np.ndarray, dtype=float, shape=(n_new, n_features)
+            The output trajectory consists of the first `n_new` frames
+            of the input, where `n_new` is the location of the first
+            outlier in the sequence.  
+        """
+        yi = self.predict([traj])[0]
+        try:
+            ind = np.where(yi == -1)[0][0]  # Find the first outlier in the trajectory
+        except IndexError:
+            ind = None
+        return traj[0:ind]
+
+    def transform(self, traj_list, y=None):
+        """Transform several sequences based on outlier detection
+
+        Parameters
+        ----------
+        traj_list : list(mdtraj.Trajectory)
+            List of A time series sequences
+
+        Returns
+        -------
+        features : list(np.ndarray), length = len(traj_list)
+            The output features will be truncated based on the first
+            outlier detected in each timeseries.
+        """
+        return [self.partial_transform(traj) for traj in traj_list]


### PR DESCRIPTION
So in some situations, it may be useful to be able to use the existing sklearn machinery for outlier detection and data trimming.  This is an initial attempt at this for discussion of the API.  Driver code below, with some outputs:

```
import os
from msmbuilder import example_datasets, cluster, msm, featurizer, lumping, utils, dataset, decomposition, outlier

sysname = os.path.split(os.getcwd())[-1]
dt = 0.25
tica_lagtime = 400
regularization_string = "_012"

X0 = dataset.dataset("./tica/tica%d%s.h5" % (tica_lagtime, regularization_string))

slicer = featurizer.FirstSlicer(2)
X = slicer.transform(X0)
Xf = np.concatenate(X[0:25])



trimmer = outlier.OneClassSVMTrimmer(nu=0.1)
trimmer.fit(X[0:10])
xi = trimmer.partial_transform(X[0])

X2 = trimmer.transform(X[0:25])

X2f = np.concatenate(X2)

hexbin(Xf[:, 0], Xf[:, 1], bins='log')
plot(X2f[:,0], X2f[:, 1], 'kx')

```

![trimming_nu0 5](https://cloud.githubusercontent.com/assets/1900459/7624139/d5c7ac10-f9b1-11e4-8921-15eba885e9d5.png)
