### PR TITLE
Add `ds.fit_transform_with`

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -9,9 +9,17 @@ Version 3.4.0.dev0 is the current development release of MSMBuilder.
 API Changes
 ~~~~~~~~~~~
 
+- Range-based slicing on dataset objects is no longer allowed. Keys in the
+  dataset object don't have to be continuous. The empty slice, e.g. ``ds[:]``
+  loads all trajectories in a list (#610).
+
 
 New Features
 ~~~~~~~~~~~~
+
+- Dataset objects have a method, ``fit_transform_with`` to simplify the common
+  pattern of applying an estimator to a dataset object to produce a new dataset
+  object (#610).
 
 
 Improvements

--- a/msmbuilder/cluster/base.py
+++ b/msmbuilder/cluster/base.py
@@ -62,9 +62,9 @@ class MultiSequenceClusterMixin(object):
             # trajectories (which is the use case that I want to be sure to
             # support), but in general the python container protocol doesn't
             # give us a generic way to make sure we merged sequences
-            concat = sequences[0]
+            concat = sequences[:][0]
             if len(sequences) > 1:
-                concat = concat.join(sequences[1:])
+                concat = concat.join(sequences[:][1:])
             concat.center_coordinates()
         else:
             raise TypeError('sequences must be a list of numpy arrays '

--- a/msmbuilder/dataset.py
+++ b/msmbuilder/dataset.py
@@ -255,6 +255,10 @@ class _BaseDataset(Sequence):
         return sum(1 for xx in self.keys())
 
     def __getitem__(self, i):
+        if isinstance(i, slice):
+            err = "Please index datasets with explicit indices or ds[:]."
+            assert i.start is None and i.step is None and i.stop is None, err
+            return [self.get(i) for i in self.keys()]
         return self.get(i)
 
     def __setitem__(self, i, x):
@@ -313,13 +317,6 @@ class NumpyDirDataset(_BaseDataset):
     _PROVENANCE_FILE = 'PROVENANCE.txt'
 
     def get(self, i, mmap=False):
-        if isinstance(i, slice):
-            items = []
-            start, stop, step = i.indices(len(self))
-            for ii in itertools.islice(itertools.count(), start, stop, step):
-                items.append(self.get(ii))
-            return items
-
         mmap_mode = 'r' if mmap else None
 
         filename = join(self.path, self._ITEM_FORMAT % i)
@@ -392,13 +389,6 @@ class HDF5Dataset(_BaseDataset):
                                         filters=_PYTABLES_DISABLE_COMPRESSION)
 
     def get(self, i, mmap=False):
-        if isinstance(i, slice):
-            items = []
-            start, stop, step = i.indices(len(self))
-            for ii in itertools.islice(itertools.count(), start, stop, step):
-                items.append(self.get(ii))
-            return items
-
         return self._handle.get_node('/', self._ITEM_FORMAT % i)[:]
 
     def keys(self):

--- a/msmbuilder/dataset.py
+++ b/msmbuilder/dataset.py
@@ -162,22 +162,15 @@ class _BaseDataset(Sequence):
 
         Parameters
         ----------
-        estimator : object with `fit` or `partial_fit` method
-            If the estimator has a ``partial_fit`` method, this will be
-            called on each trajectory in the dataset. Otherwise, the ``fit``
-            method will be called on all dataset items.
+        estimator : BaseEstimator
+            estimator.fit will be called on this dataset.
 
         Returns
         -------
         estimator
             The fit estimator.
         """
-        if hasattr(estimator, 'partial_fit'):
-            for item in self:
-                estimator.partial_fit(item)
-        else:
-            estimator.fit([item for item in self])
-
+        estimator.fit(self)
         return estimator
 
     def transform_with(self, estimator, out_ds, fmt=None):

--- a/msmbuilder/tests/test_dataset.py
+++ b/msmbuilder/tests/test_dataset.py
@@ -86,8 +86,6 @@ def test_3():
          np.testing.assert_array_equal(ds[:][1], ds[1])
          np.testing.assert_array_equal(ds[:][2], ds[2])
 
-         np.testing.assert_array_equal(ds[1:][0], ds[1])
-         np.testing.assert_array_equal(ds[1:][1], ds[2])
 
     finally:
         shutil.rmtree(path)
@@ -137,8 +135,6 @@ def test_hdf5_1():
         np.testing.assert_array_equal(ds[:][1], ds[1])
         np.testing.assert_array_equal(ds[:][2], ds[2])
 
-        np.testing.assert_array_equal(ds[1:][0], ds[1])
-        np.testing.assert_array_equal(ds[1:][1], ds[2])
 
         ds.close()
         with dataset('ds.h5') as ds:
@@ -260,8 +256,6 @@ def test_append_dirnpy():
         np.testing.assert_array_equal(ds[:][1], ds[1])
         np.testing.assert_array_equal(ds[:][2], ds[2])
 
-        np.testing.assert_array_equal(ds[1:][0], ds[1])
-        np.testing.assert_array_equal(ds[1:][1], ds[2])
 
     finally:
         shutil.rmtree(path)
@@ -275,14 +269,16 @@ def test_items():
         ds[1] = np.random.randn(10, 2)
         ds[5] = np.random.randn(10, 3)
 
-        # NOTE!
-        # ds[:] does not work for non-contiguous keys.
 
         keys = [0, 1, 5]
 
         for i, (k, v) in enumerate(ds.items()):
             assert k == keys[i]
             np.testing.assert_array_equal(ds[k], v)
+
+        np.testing.assert_array_equal(ds[:][0], ds[0])
+        np.testing.assert_array_equal(ds[:][1], ds[1])
+        np.testing.assert_array_equal(ds[:][2], ds[5])
 
         ds.close()
 


### PR DESCRIPTION
I think this makes a nice convenience addition to API usage

```python
diheds = dataset("diheds")
tica = diheds.fit_transform_with(tICA(), 'tica')
kmeans = tica.fit_transform_with(KMeans(), 'kmeans')
msm = kmeans.fit_with(MarkovStateModel())
```

This PR also addresses dataset indexing semantics a little. cc #539 . We should treat datasets as dictionary-like except iteration happens over values instead of keys. This PR disables slice indexing except for `ds[:]`, which is well-defined: It returns a list of all entries instead of an iterator over all entries. This is useful for doing things like:

```python
tica = ds("tica")
txx = np.concatenate(tica[:])
plt.hexbin(txx[:,0], txx[:,1])
```