### PR TITLE
Use proper rst syntax in changelog

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -4,33 +4,33 @@ Changelog
 v3.3 (Unreleased)
 -----------------
 
-- `GaussianHMM` and `VonMisesHMM` is rewritten to feature higher code reuse
+- ``GaussianHMM`` and ``VonMisesHMM`` is rewritten to feature higher code reuse
   and code quality (#583, #582, #584, #572, #570).
-- `KDTree` can find n nearest points to e.g. a cluster center (#599).
-- `PCCAPlus` is compatible with scipy 0.16 (#620).
+- ``KDTree`` can find n nearest points to e.g. a cluster center (#599).
+- ``PCCAPlus`` is compatible with scipy 0.16 (#620).
 - Documentation improvements (#618, #608, #604, #602)
 - Test improvements, especially for Windows (#593, #590, #588, #579, #578,
   #577, #576)
-- The command line flag for featurizers `--out` now saves the featurizer as
+- The command line flag for featurizers ``--out`` now saves the featurizer as
   a pickle file. This is consistent with other command-line commands
   (#546).
-- Bug fix: `MarkovStateModel.sample()` produced trajectories of incorrect
+- Bug fix: ``MarkovStateModel.sample()`` produced trajectories of incorrect
   length. This function is still deprecated (#556).
-- `Slicer` featurizer can slice feature arrays as part of a pipeline
+- ``Slicer`` featurizer can slice feature arrays as part of a pipeline
   (#567).
 
 v3.2 (April 14, 2015)
 ---------------------
 
-- `tICA` ignores too-short trajectories during fitting instead of raising
+- ``tICA`` ignores too-short trajectories during fitting instead of raising
   an exception
 - New methods for sampling from MSM models
 - Datasets can be opened in "append" mode
 - Compatibility with scipy 0.16
-- `utils.dump` saves using the pickle protocol. `utils.load` is backwards
+- ``utils.dump`` saves using the pickle protocol. ``utils.load`` is backwards
   compatible.
-- The command line flag for featurizers `--out` is deprecated. Use
-  `--transformed` instead. This is consistent with other command-line
+- The command line flag for featurizers ``--out`` is deprecated. Use
+  ``--transformed`` instead. This is consistent with other command-line
   commands.
 - Bug fixes
 


### PR DESCRIPTION
Namely, double-backtick for monospace