### PR TITLE
Change default n_timescales to n_states - 1

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -27,6 +27,9 @@ v3.3 (Unreleased)
 - ``MarkovStateModel.draw_samples`` failed if discrete trajectories did not
   contain every possible state (#638). Function can now accept a single
   trajectory, as well as a list of them.
+- The default number of timescales in ``MarkovStateModel`` is now one less
+  than the number of states (was 10). This addresses some bugs with
+  ``implied_timescales`` and PCCA(+) (#603).
 
 v3.2 (April 14, 2015)
 ---------------------

--- a/msmbuilder/msm/msm.py
+++ b/msmbuilder/msm/msm.py
@@ -350,10 +350,8 @@ class MarkovStateModel(BaseEstimator, _MappingTransformMixin, _SampleMSMMixin):
                     self._left_eigenvectors,
                     self._right_eigenvectors)
 
-        n_timescales = self.n_timescales
-        if n_timescales is None:
-            n_timescales = self.n_states_ - 1
-        n_timescales = min(n_timescales, self.n_states_ - 1)
+        n_timescales = min(self.n_timescales if self.n_timescales is not None
+                           else self.n_states_ - 1, self.n_states_ - 1)
 
         k = n_timescales + 1
         u, lv, rv = _solve_msm_eigensystem(self.transmat_, k)
@@ -582,10 +580,8 @@ Timescales:
         if self.reversible_type is None:
             raise NotImplementedError('reversible_type must be "mle" or "transpose"')
 
-        n_timescales = self.n_timescales
-        if n_timescales is None:
-            n_timescales = self.n_states_ - 1
-        n_timescales = min(n_timescales, self.n_states_ - 1)
+        n_timescales = min(self.n_timescales if self.n_timescales is not None
+                           else self.n_states_ - 1, self.n_states_ - 1)
 
         u, lv, rv = self._get_eigensystem()
 

--- a/msmbuilder/msm/msm.py
+++ b/msmbuilder/msm/msm.py
@@ -47,7 +47,7 @@ class MarkovStateModel(BaseEstimator, _MappingTransformMixin, _SampleMSMMixin):
         The lag time of the model
     n_timescales : int, optional
         The number of dynamical timescales to calculate when diagonalizing
-        the transition matrix.
+        the transition matrix. If not specified, it will compute n_states - 1
     reversible_type : {'mle', 'transpose', None}
         Method by which the reversibility of the transition matrix
         is enforced. 'mle' uses a maximum likelihood method that is
@@ -107,7 +107,7 @@ class MarkovStateModel(BaseEstimator, _MappingTransformMixin, _SampleMSMMixin):
         The equilibrium population (stationary eigenvector) of transmat_
     """
 
-    def __init__(self, lag_time=1, n_timescales=10, reversible_type='mle',
+    def __init__(self, lag_time=1, n_timescales=None, reversible_type='mle',
                  ergodic_cutoff='on', prior_counts=0, sliding_window=True,
                  verbose=True):
         self.reversible_type = reversible_type
@@ -353,6 +353,7 @@ class MarkovStateModel(BaseEstimator, _MappingTransformMixin, _SampleMSMMixin):
         n_timescales = self.n_timescales
         if n_timescales is None:
             n_timescales = self.n_states_ - 1
+        n_timescales = min(n_timescales, self.n_states_ - 1)
 
         k = n_timescales + 1
         u, lv, rv = _solve_msm_eigensystem(self.transmat_, k)
@@ -581,9 +582,11 @@ Timescales:
         if self.reversible_type is None:
             raise NotImplementedError('reversible_type must be "mle" or "transpose"')
 
-        n_timescales = min(self.n_timescales, self.n_states_ - 1)
+        n_timescales = self.n_timescales
         if n_timescales is None:
             n_timescales = self.n_states_ - 1
+        n_timescales = min(n_timescales, self.n_states_ - 1)
+
         u, lv, rv = self._get_eigensystem()
 
         sigma2 = np.zeros(n_timescales + 1)

--- a/msmbuilder/tests/test_lumping.py
+++ b/msmbuilder/tests/test_lumping.py
@@ -68,3 +68,32 @@ def test_from_msm():
     msm = MarkovStateModel()
     msm.fit(assignments)
     pccaplus = PCCAPlus.from_msm(msm, 2)
+
+
+def test_ntimescales_1():
+    # see issue #603
+    trajs = [np.random.randint(0, 30, size=500) for _ in range(5)]
+    pccap = PCCAPlus(n_macrostates=11).fit(trajs)
+
+    lumped_trajs = pccap.transform(trajs)
+    assert len(np.unique(lumped_trajs)) == 11
+
+
+def test_ntimescales_2():
+    # see issue #603
+    trajs = [np.random.randint(0, 30, size=500) for _ in range(5)]
+    msm = MarkovStateModel().fit(trajs)
+
+    pccap = PCCAPlus.from_msm(msm, 11)
+    lumped_trajs = pccap.transform(trajs)
+    assert len(np.unique(lumped_trajs)) == 11
+
+
+def test_ntimescales_3():
+    # see issue #603
+    trajs = [np.random.randint(0, 30, size=500) for _ in range(5)]
+    msm = MarkovStateModel(n_timescales=10).fit(trajs)
+
+    pccap = PCCAPlus.from_msm(msm, 11)
+    lumped_trajs = pccap.transform(trajs)
+    assert len(np.unique(lumped_trajs)) == 11

--- a/msmbuilder/tests/test_param_sweep.py
+++ b/msmbuilder/tests/test_param_sweep.py
@@ -65,3 +65,10 @@ def test_multi_params():
 
     # this is redundant, but w/e
     assert len(set(params)) == 6
+
+
+def test_ntimescales():
+    # see issue #603
+    trajs = [np.random.randint(0,30,500) for _ in range(5)]
+    its = implied_timescales(trajs, [1,2,3], n_timescales=11)
+    assert its.shape[1] == 11


### PR DESCRIPTION
The default for the number of timescales was 10. This caused problems
with implied_timescales (needed to pass n_timescales twice) and with
PCCA(+) (would fail for > 10 macrostates).

Fixes #603