### PR TITLE
Load topology in SuperposeFeaturizer

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -27,6 +27,8 @@ v3.3 (Unreleased)
 - ``MarkovStateModel.draw_samples`` failed if discrete trajectories did not
   contain every possible state (#638). Function can now accept a single
   trajectory, as well as a list of them.
+- ``SuperposeFeaturizer`` now respects the topology argument when loading the
+  reference trajectory (#555).
 
 v3.2 (April 14, 2015)
 ---------------------

--- a/msmbuilder/cmdline.py
+++ b/msmbuilder/cmdline.py
@@ -267,11 +267,19 @@ class NumpydocClassCommand(Command):
         init_args = get_init_argspec(self.klass)[0]
         kwargs = {}
 
-        for k, v in args.__dict__.items():
-            # these are all of the specified options from the command line
-            # some of them correspond to __init__ args for self.klass, and
-            # others are "extra" arguments that weren't part of klass
+        # these are all of the specified options from the command line
+        # some of them correspond to __init__ args for self.klass, and
+        # others are "extra" arguments that weren't part of klass
 
+        # we do the "extra" arguments first, so we can use them when
+        # loading init args
+
+        for k, v in args.__dict__.items():
+            if k not in init_args:
+                # set the others as attributes on self
+                setattr(self, k, v)
+
+        for k, v in args.__dict__.items():
             if k in init_args:
                 # put the ones for klass.__init__ in a dict
                 kwargs[k] = v
@@ -279,9 +287,6 @@ class NumpydocClassCommand(Command):
                 if hasattr(self, '_%s_type' % k):
                     kwargs[k] = getattr(self, '_%s_type' % k)(v)
 
-            else:
-                # set the others as attributes on self
-                setattr(self, k, v)
 
         # make an instantiation of `klass`, populated with the requested
         # arguments from the command line

--- a/msmbuilder/commands/featurizer.py
+++ b/msmbuilder/commands/featurizer.py
@@ -103,7 +103,14 @@ class SuperposeFeaturizerCommand(FeaturizerCommand):
     _concrete = True
 
     def _reference_traj_type(self, fn):
-        return md.load(fn)
+        if self.top.strip() == "":
+            top = None
+        else:
+            top = os.path.expanduser(self.top)
+            err = ("Couldn't find topology file '{}' "
+                   "when loading reference trajectory".format(top))
+            assert os.path.exists(top), err
+        return md.load(fn, top=top)
 
     def _atom_indices_type(self, fn):
         if fn is None:

--- a/msmbuilder/tests/test_commands.py
+++ b/msmbuilder/tests/test_commands.py
@@ -167,12 +167,11 @@ def test_transform_command_1():
               "--metric rmsd".format(data_home=get_data_home()))
 
 def test_transform_command_2():
-    def test_transform_command_1():
-        with tempdir():
-            shell("msmb KCenters -i {data_home}/alanine_dipeptide/trajectory_0.dcd "
-                  "-o model.pkl --top {data_home}/alanine_dipeptide/ala2.pdb "
-                  "--metric rmsd "
-                  "--stride 2".format(data_home=get_data_home()))
+    with tempdir():
+        shell("msmb KCenters -i {data_home}/alanine_dipeptide/trajectory_0.dcd "
+              "-o model.pkl --top {data_home}/alanine_dipeptide/ala2.pdb "
+              "--metric rmsd "
+              "--stride 2".format(data_home=get_data_home()))
 
 def test_help():
     shell('msmb -h')

--- a/msmbuilder/tests/test_commands.py
+++ b/msmbuilder/tests/test_commands.py
@@ -136,6 +136,20 @@ def test_superpose_featurizer():
         assert ds[0].shape[1] == len(np.loadtxt('all.txt'))
         print(ds.provenance)
 
+def test_superpose_featurizer_reftop():
+    # see issue #555
+    with tempdir():
+        shell('msmb AtomIndices -o all.txt --all -a -p %s/alanine_dipeptide/ala2.pdb' % get_data_home()),
+        shell("msmb SuperposeFeaturizer --trjs '{data_home}/alanine_dipeptide/*.dcd'"
+              " --transformed distances --atom_indices all.txt"
+              " --reference_traj {data_home}/alanine_dipeptide/trajectory_0.dcd"
+              " --top {data_home}/alanine_dipeptide/ala2.pdb".format(
+            data_home=get_data_home()))
+        ds = dataset('distances')
+        assert len(ds) == 10
+        assert ds[0].shape[1] == len(np.loadtxt('all.txt'))
+        print(ds.provenance)
+
 
 def test_atom_pairs_featurizer():
     with tempdir():
@@ -199,3 +213,4 @@ def test_convert_chunked_project_1():
         assert set(record.keys()) == set(('filename', 'chunks'))
         assert record['filename'] == 'traj-00000000.dcd'
         assert sorted(glob.glob('%s/*.dcd' % root)) == record['chunks']
+


### PR DESCRIPTION
The command line now uses the topology argument for ``SuperposeFeaturizer``.
This required reorganizing the comandline parser slightly. It will load
all the "extra" arguments prior to trying to construct the instantiation
of the class the command line wraps.

fixes #555 

