### PR TITLE
PR for describe_features method

### DIFF
--- a/msmbuilder/featurizer/featurizer.py
+++ b/msmbuilder/featurizer/featurizer.py
@@ -506,8 +506,8 @@ class ContactFeaturizer(Featurizer):
         distances,residue_indices = md.compute_contacts(traj, self.contacts, self.scheme, self.ignore_nonprotein)
         n = residue_indices.shape[0]
         aind = ["N/A"] * n
-        resSeq = [[traj.top.residue(j).resSeq for j in i] for i in residue_indices]
-        resid = [[traj.top.residue(j).index for j in i] for i in residue_indices]
+        resSeq = [np.array([traj.top.residue(j).resSeq for j in i]) for i in residue_indices]
+        resid = [np.array([traj.top.residue(j).index for j in i]) for i in residue_indices]
         resnames = [[traj.topology.residue(j).name for j in i ] for i in resid]
         bigclass = [self.contacts] * n
         smallclass = [self.scheme] * n

--- a/msmbuilder/featurizer/featurizer.py
+++ b/msmbuilder/featurizer/featurizer.py
@@ -277,7 +277,7 @@ class DihedralFeaturizer(Featurizer):
                 str(known), str(types)))
 
     def describe_features(self, traj):
-        """Return a Pandas Dataframe describing the features."""
+        """Return a Pandas Dataframe describing the Dihderal features."""
         x = []
         for a in self.types:
             func = getattr(md, 'compute_%s' % a)
@@ -500,6 +500,28 @@ class ContactFeaturizer(Featurizer):
         """
         distances, _ = md.compute_contacts(traj, self.contacts, self.scheme, self.ignore_nonprotein)
         return distances
+
+    def describe_features(self, traj):
+        """Return a Pandas Dataframe describing the features in Contacts."""
+        x = []
+        #fill in the atom indices using just the first frame
+        distances,residue_indices = md.compute_contacts(traj, self.contacts, self.scheme, self.ignore_nonprotein)
+        n = residue_indices.shape[0]
+        aind = ["N/A"] * n
+        resSeq = [[traj.top.residue(j).resSeq for j in i] for i in residue_indices]
+        resid = [[traj.top.residue(j).index for j in i] for i in residue_indices]
+        resnames = [[traj.topology.residue(j).name for j in i ] for i in resid]
+        bigclass = [self.contacts] * n
+        smallclass = [self.scheme] * n
+        otherInfo = [self.ignore_nonprotein]*n
+
+        for i in range(n):
+            d_i = dict(resname=resnames[i], atomind=aind[i],resSeq=resSeq[i], resid=resid[i],\
+                               otherInfo=otherInfo[i], bigclass=bigclass[i], smallclass=smallclass[i])
+            x.append(d_i)
+
+        return x
+
 
 
 class GaussianSolventFeaturizer(Featurizer):

--- a/msmbuilder/featurizer/featurizer.py
+++ b/msmbuilder/featurizer/featurizer.py
@@ -268,8 +268,6 @@ class DihedralFeaturizer(Featurizer):
             types = [types]
         self.types = list(types)  # force a copy
         self.sincos = sincos
-        self.wrote_atom_indices = False
-        self.atom_indices = []
 
         known = {'phi', 'psi', 'omega', 'chi1', 'chi2', 'chi3', 'chi4'}
         if not set(types).issubset(known):
@@ -335,7 +333,7 @@ class DihedralFeaturizer(Featurizer):
         x = []
         for a in self.types:
             func = getattr(md, 'compute_%s' % a)
-            indices,y = func(traj)
+            _,y = func(traj)
             if self.sincos:
                 x.extend([np.sin(y), np.cos(y)])
             else:

--- a/msmbuilder/featurizer/featurizer.py
+++ b/msmbuilder/featurizer/featurizer.py
@@ -276,6 +276,41 @@ class DihedralFeaturizer(Featurizer):
             raise ValueError('angles must be a subset of %s. you supplied %s' % (
                 str(known), str(types)))
 
+    def describe_features(self, traj):
+        """Return a Pandas Dataframe describing the features."""
+        x = []
+        for a in self.types:
+            func = getattr(md, 'compute_%s' % a)
+            aind, y = func(traj)
+            n = len(aind)
+
+            resSeq = [(np.unique([traj.top.atom(j).residue.resSeq for j in i])) for i in aind]
+            resid = [(np.unique([traj.top.atom(j).residue.index for j in i])) for i in aind]
+            resnames = [[traj.topology.residue(j).name for j in i ] for i in resid]
+
+
+            bigclass = ["dihedral"] * n
+            smallclass = [a] * n
+
+            if self.sincos:
+                #x.extend([np.sin(y), np.cos(y)])
+                aind =  list(aind) * 2
+                resnames = resnames * 2
+                resSeq = resSeq * 2
+                resid = resid * 2
+                otherInfo = (["sin"] * n) + (["cos"] * n)
+                bigclass = bigclass * 2
+                smallclass = smallclass * 2
+            else:
+                otherInfo = ["nosincos"] * n
+
+            for i in range(len(resnames)):
+                d_i = dict(resname=resnames[i], atomind=aind[i],resSeq=resSeq[i], resid=resid[i],\
+                           otherInfo=otherInfo[i], bigclass=bigclass[i], smallclass=smallclass[i])
+                x.append(d_i)
+
+        return x
+
     def partial_transform(self, traj):
         """Featurize an MD trajectory into a vector space via calculation
         of dihedral (torsion) angles
@@ -303,16 +338,8 @@ class DihedralFeaturizer(Featurizer):
             indices,y = func(traj)
             if self.sincos:
                 x.extend([np.sin(y), np.cos(y)])
-                if not self.wrote_atom_indices:
-                    self.atom_indices.extend(indices)
-                    self.atom_indices.extend(indices)
             else:
                 x.append(y)
-                if not self.wrote_atom_indices:
-                    self.atom_indices.extend(indices)
-        if not self.wrote_atom_indices:
-            self.wrote_atom_indices = True
-            self.atom_indices = np.array(self.atom_indices)
         return np.hstack(x)
 
 
@@ -348,6 +375,37 @@ class KappaAngleFeaturizer(Featurizer):
 
         assert result.shape == (traj.n_frames, traj.n_residues - 4)
         return result
+
+    def describe_features(self, traj):
+        """Return a Pandas Dataframe describing the Kappa angle features."""
+        x = []
+        #fill in the atom indices using just the first frame
+        res_ = self.partial_transform(traj[0])
+        if self.atom_indices is not None:
+            aind = self.atom_indices
+            n = len(aind)
+            resSeq = [(np.unique([traj.top.atom(j).residue.resSeq for j in i])) for i in aind]
+            resid = [(np.unique([traj.top.atom(j).residue.index for j in i])) for i in aind]
+            resnames = [[traj.topology.residue(j).name for j in i ] for i in resid]
+            bigclass = ["angle"] * n
+            smallclass = ["kappa"] * n
+
+            if self.cos:
+                otherInfo = (["cos"] * n)
+            else:
+                otherInfo = ["nocos"] * n
+
+            assert len(self.atom_indices)==len(resnames)
+
+            for i in range(len(resnames)):
+                    d_i = dict(resname=resnames[i], atomind=aind[i],resSeq=resSeq[i], resid=resid[i],\
+                               otherInfo=otherInfo[i], bigclass=bigclass[i], smallclass=smallclass[i])
+                    x.append(d_i)
+
+            return x
+        else:
+            raise UserWarning("Cannot describe features for trajectories with fewer than 5 alpha carbon\
+                              using KappaAngle Featurizer")
 
 
 class SASAFeaturizer(Featurizer):

--- a/msmbuilder/featurizer/featurizer.py
+++ b/msmbuilder/featurizer/featurizer.py
@@ -275,7 +275,7 @@ class DihedralFeaturizer(Featurizer):
                 str(known), str(types)))
 
     def describe_features(self, traj):
-        """Return a Pandas Dataframe describing the Dihderal features."""
+        """Return a list of dictionaries describing the Dihderal features."""
         x = []
         for a in self.types:
             func = getattr(md, 'compute_%s' % a)
@@ -375,7 +375,7 @@ class KappaAngleFeaturizer(Featurizer):
         return result
 
     def describe_features(self, traj):
-        """Return a Pandas Dataframe describing the Kappa angle features."""
+        """Return a list of dictionaries describing the Kappa angle features."""
         x = []
         #fill in the atom indices using just the first frame
         res_ = self.partial_transform(traj[0])
@@ -500,7 +500,7 @@ class ContactFeaturizer(Featurizer):
         return distances
 
     def describe_features(self, traj):
-        """Return a Pandas Dataframe describing the features in Contacts."""
+        """Return a list of dictionaries describing the features in Contacts."""
         x = []
         #fill in the atom indices using just the first frame
         distances,residue_indices = md.compute_contacts(traj, self.contacts, self.scheme, self.ignore_nonprotein)


### PR DESCRIPTION
This PR implements the describe_features method for 3 of the most commonly used featurziers ```ContactFeaturizer, DihedralFeaturizer, & KappaAngleFeaturizer```. Most, if not all, of the code was inspired by Kyle's previous attempt to get this going. 

For the ```DihedralFeaturizer``` 
```python

In [13]: f=DihedralFeaturizer()

In [14]: df = pd.DataFrame(f.describe_features(t))

In [15]: df[:1]
Out[15]: 
            atomind  bigclass otherInfo  resSeq   resid     resname smallclass
0  [22, 24, 26, 34]  dihedral       sin  [1, 2]  [0, 1]  [LYS, ASP]        phi
```

For the ```ContactFeaturizer``` 
```python
In [16]: f = ContactFeaturizer()

In [17]: df = pd.DataFrame(f.describe_features(t))
 
In [18]: df[:1]
Out[18]: 
  atomind bigclass otherInfo  resSeq   resid     resname     smallclass
0     N/A      all      True  [1, 4]  [0, 3]  [LYS, TRP]  closest-heavy
```

For the ```KappaAngleFeaturizer```
```python
In [26]: f = KappaAngleFeaturizer()

In [27]: df = pd.DataFrame(f.describe_features(t))

In [28]: df[:1]
Out[28]: 
       atomind bigclass otherInfo     resSeq      resid          resname  \
0  [4, 38, 78]    angle       cos  [1, 3, 5]  [0, 2, 4]  [LYS, VAL, GLU]   

  smallclass  
0      kappa 
 ```