### PR TITLE
featurizer: rmsd's of frames to any number of reference frames

### DIFF
--- a/msmbuilder/commands/__init__.py
+++ b/msmbuilder/commands/__init__.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 from .featurizer import (AtomPairsFeaturizerCommand, ContactFeaturizerCommand,
                          DihedralFeaturizerCommand, DRIDFeaturizerCommand,
                          SuperposeFeaturizerCommand, KappaAngleFeaturizerCommand,
-                         AlphaAngleFeaturizerCommand)
+                         AlphaAngleFeaturizerCommand, StrucRMSDFeaturizerCommand)
 from .fit import GaussianHMMCommand
 from .fit_transform import KMeansCommand, KCentersCommand
 from .transform import TransformCommand

--- a/msmbuilder/commands/featurizer.py
+++ b/msmbuilder/commands/featurizer.py
@@ -12,7 +12,8 @@ from ..dataset import dataset, MDTrajDataset
 from ..featurizer import (AtomPairsFeaturizer, SuperposeFeaturizer,
                           DRIDFeaturizer, DihedralFeaturizer,
                           ContactFeaturizer, GaussianSolventFeaturizer,
-                          KappaAngleFeaturizer, AlphaAngleFeaturizer)
+                          KappaAngleFeaturizer, AlphaAngleFeaturizer,
+                          StrucRMSDFeaturizer)
 
 
 class FeaturizerCommand(NumpydocClassCommand):
@@ -106,6 +107,26 @@ class AtomPairsFeaturizerCommand(FeaturizerCommand):
         if fn is None:
             return None
         return np.loadtxt(fn, dtype=int, ndmin=2)
+
+
+class StrucRMSDFeaturizerCommand(FeaturizerCommand):
+    klass = StrucRMSDFeaturizer
+    _concrete = True
+
+    def _reference_traj_type(self, fn):
+        if self.top.strip() == "":
+            top = None
+        else:
+            top = os.path.expanduser(self.top)
+            err = ("Couldn't find topology file '{}' "
+                   "when loading reference trajectory".format(top))
+            assert os.path.exists(top), err
+        return md.load(fn, top=top)
+
+    def _atom_indices_type(self, fn):
+        if fn is None:
+            return None
+        return np.loadtxt(fn, dtype=int, ndmin=1)
 
 
 class SuperposeFeaturizerCommand(FeaturizerCommand):

--- a/msmbuilder/featurizer/featurizer.py
+++ b/msmbuilder/featurizer/featurizer.py
@@ -16,7 +16,7 @@ import mdtraj as md
 from sklearn.base import TransformerMixin
 import sklearn.pipeline
 from sklearn.externals.joblib import Parallel, delayed
-import libdistance
+from msmbuilder import libdistance
 
 from ..base import BaseEstimator
 

--- a/msmbuilder/featurizer/featurizer.py
+++ b/msmbuilder/featurizer/featurizer.py
@@ -254,6 +254,8 @@ class StrucRMSDFeaturizer(Featurizer):
         result = np.array(x)
         return np.transpose(x)
 
+        # test 2
+
         # for i in range(0, self.reference_traj.n_frames):
         #     y = np.array([md.rmsd(traj, self.reference_traj, i)])
         #     x = np.append(x,y)

--- a/msmbuilder/featurizer/featurizer.py
+++ b/msmbuilder/featurizer/featurizer.py
@@ -16,6 +16,7 @@ import mdtraj as md
 from sklearn.base import TransformerMixin
 import sklearn.pipeline
 from sklearn.externals.joblib import Parallel, delayed
+import libdistance
 
 from ..base import BaseEstimator
 
@@ -249,7 +250,7 @@ class StrucRMSDFeaturizer(Featurizer):
         --------
         transform : simultaneously featurize a collection of MD trajectories
         """
-        result = cdist(traj, self.reference_traj, 'rmsd')
+        result = libdistance.cdist(traj, self.reference_traj, 'rmsd')
         return result
 
 

--- a/msmbuilder/featurizer/featurizer.py
+++ b/msmbuilder/featurizer/featurizer.py
@@ -253,6 +253,7 @@ class StrucRMSDFeaturizer(Featurizer):
             
         result = np.array(x)
         return np.transpose(x)
+        # test
         # for i in range(0, self.reference_traj.n_frames):
         #     y = np.array([md.rmsd(traj, self.reference_traj, i)])
         #     x = np.append(x,y)

--- a/msmbuilder/featurizer/featurizer.py
+++ b/msmbuilder/featurizer/featurizer.py
@@ -252,15 +252,7 @@ class StrucRMSDFeaturizer(Featurizer):
             x.append(y)
             
         result = np.array(x)
-        return np.transpose(x)
-
-        # test 2
-
-        # for i in range(0, self.reference_traj.n_frames):
-        #     y = np.array([md.rmsd(traj, self.reference_traj, i)])
-        #     x = np.append(x,y)
-
-        # return np.hstack(x)
+        return np.transpose(result)
 
 
 class AtomPairsFeaturizer(Featurizer):

--- a/msmbuilder/featurizer/featurizer.py
+++ b/msmbuilder/featurizer/featurizer.py
@@ -202,7 +202,9 @@ class SuperposeFeaturizer(Featurizer):
 
 
 class StrucRMSDFeaturizer(Featurizer):
-    """Featurizer which inputs a trajectory to be analyzed ('traj') and a
+    """Featurizer based on RMSD to one or more reference structures.
+
+    This featurizer inputs a trajectory to be analyzed ('traj') and a
     reference trajectory ('ref') and outputs the RMSD of each frame of
     traj with respect to each frame in ref. The output is a numpy array
     with n_rows = traj.n_frames and n_columns = ref.n_frames.
@@ -225,7 +227,6 @@ class StrucRMSDFeaturizer(Featurizer):
         else:
             self.superpose_atom_indices = superpose_atom_indices
         self.reference_traj = reference_traj
-#        self.n_features = len(self.atom_indices)
 
     def partial_transform(self, traj):
         """Featurize an MD trajectory into a vector space via distance
@@ -248,7 +249,6 @@ class StrucRMSDFeaturizer(Featurizer):
         --------
         transform : simultaneously featurize a collection of MD trajectories
         """
-        traj.superpose(self.reference_traj, atom_indices=self.superpose_atom_indices)
         x = []
         for i in range(0, self.reference_traj.n_frames):
             y = md.rmsd(traj, self.reference_traj, i)

--- a/msmbuilder/featurizer/featurizer.py
+++ b/msmbuilder/featurizer/featurizer.py
@@ -249,13 +249,8 @@ class StrucRMSDFeaturizer(Featurizer):
         --------
         transform : simultaneously featurize a collection of MD trajectories
         """
-        x = []
-        for i in range(0, self.reference_traj.n_frames):
-            y = md.rmsd(traj, self.reference_traj, i)
-            x.append(y)
-            
-        result = np.array(x)
-        return np.transpose(result)
+        result = cdist(traj, self.reference_traj, 'rmsd')
+        return result
 
 
 class AtomPairsFeaturizer(Featurizer):

--- a/msmbuilder/featurizer/featurizer.py
+++ b/msmbuilder/featurizer/featurizer.py
@@ -247,11 +247,17 @@ class StrucRMSDFeaturizer(Featurizer):
         """
         traj.superpose(self.reference_traj, atom_indices=self.superpose_atom_indices)
         x = []
-        for i in range (0, self.reference_traj.n_frames):
-            y = np.array([md.rmsd(traj, self.reference_traj, i)])
-            x = np.append(x,y)
+        for i in range(0, self.reference_traj.n_frames):
+            y = md.rmsd(traj, self.reference_traj, i)
+            x.append(y)
+            
+        result = np.array(x)
+        return np.transpose(x)
+        # for i in range(0, self.reference_traj.n_frames):
+        #     y = np.array([md.rmsd(traj, self.reference_traj, i)])
+        #     x = np.append(x,y)
 
-        return np.hstack(x)
+        # return np.hstack(x)
 
 
 class AtomPairsFeaturizer(Featurizer):

--- a/msmbuilder/featurizer/featurizer.py
+++ b/msmbuilder/featurizer/featurizer.py
@@ -202,7 +202,10 @@ class SuperposeFeaturizer(Featurizer):
 
 
 class StrucRMSDFeaturizer(Featurizer):
-    """Featurizer based on overall RMSD to a set of reference structures.
+    """Featurizer which inputs a trajectory to be analyzed ('traj') and a
+    reference trajectory ('ref') and outputs the RMSD of each frame of
+    traj with respect to each frame in ref. The output is a numpy array
+    with n_rows = traj.n_frames and n_columns = ref.n_frames.
 
     Parameters
     ----------

--- a/msmbuilder/libdistance/libdistance.pyx
+++ b/msmbuilder/libdistance/libdistance.pyx
@@ -138,9 +138,9 @@ def cdist(XA, XB, const char* metric):
 
     Parameters
     ----------
-    XA : array, shape = (n_samples, n_features) or md.Trajectory
+    XA : array, shape = (na_samples, m_features) or md.Trajectory
         The data array
-    XB : array, shape = (n_samples, n_features) or md.Trajectory
+    XB : array, shape = (nb_samples, m_features) or md.Trajectory
         The reference array
     metric : {"euclidean", "sqeuclidean", "cityblock", "chebyshev", "canberra",
               "braycurtis", "hamming", "jaccard", "cityblock", "rmsd"}
@@ -149,11 +149,9 @@ def cdist(XA, XB, const char* metric):
 
     Returns
     -------
-    Y : ndarray
-        A :math:`n_A` by :math:`n_B` distance matrix is returned.
-        For each :math:`i` and :math:`j`, the metric
-        ``dist(u=XA[i], v=XB[j])`` is computed and stored in the
-        :math:`ij` th entry.
+    Y : array, shape = (na_samples, nb_samples)
+        For each sample i in XA and each sample j in XB
+        ``dist(u=XA[i], v=XB[j])`` is computed and stored in Y[i,j]
 
     Note
     ----

--- a/msmbuilder/libdistance/libdistance.pyx
+++ b/msmbuilder/libdistance/libdistance.pyx
@@ -1,8 +1,8 @@
 # cython: c_string_type=str, c_string_encoding=ascii
 
 # Author: Robert McGibbon <rmcgibbo@gmail.com>
-# Contributors:
-# Copyright (c) 2014, Stanford University
+# Contributors: Brooke Husic <brookehusic@gmail.com>
+# Copyright (c) 2015, Stanford University
 # All rights reserved.
 
 from __future__ import print_function
@@ -43,6 +43,11 @@ cdef extern from "pdist.hpp":
     void pdist_float_X_indices(const float* X, const char* metric, npy_intp n,
         npy_intp m, const npy_intp* X_indices, npy_intp n_X_indices,
         double* out) nogil
+cdef extern from "cdist.hpp":
+    void cdist_double(const double* XA, const double* XB, const char* metric,
+        npy_intp na, npy_intp nb, npy_intp m, double* out) nogil
+    void cdist_float(const float* XA, const float* XB, const char* metric,
+        npy_intp na, npy_intp nb, npy_intp m, double* out) nogil
 cdef extern from "dist.hpp":
     void dist_double(const double* X, const double* y, const char* metric,
         npy_intp n, npy_intp m, double* out) nogil
@@ -124,6 +129,56 @@ def assign_nearest(X, Y, const char* metric, npy_intp[::1] X_indices=None):
         return _assign_nearest_float(X, Y, metric, X_indices)
     else:
         raise TypeError('X and y must be both float32 or float64')
+
+
+def cdist(XA, XB, const char* metric):
+    """cdist(XA, XB, metric):
+
+    Computes distance between each pair of the two collections of inputs.
+
+    Parameters
+    ----------
+    XA : array, shape = (n_samples, n_features) or md.Trajectory
+        The data array
+    XB : array, shape = (n_samples, n_features) or md.Trajectory
+        The reference array
+    metric : {"euclidean", "sqeuclidean", "cityblock", "chebyshev", "canberra",
+              "braycurtis", "hamming", "jaccard", "cityblock", "rmsd"}
+        The distance metric to use. metric = "rmsd" requires that X be of type
+        md.Trajectory; other distance metrics require that it be a numpy array
+
+    Returns
+    -------
+    Y : ndarray
+        A :math:`n_A` by :math:`n_B` distance matrix is returned.
+        For each :math:`i` and :math:`j`, the metric
+        ``dist(u=XA[i], v=XB[j])`` is computed and stored in the
+        :math:`ij` th entry.
+
+    Note
+    ----
+    Not implemented for X_indices != None
+
+    See Also
+    --------
+    mdtraj.rmsd
+    scipy.spatial.distance.cdist
+    """
+    if (isinstance(XA, md.Trajectory) and isinstance(XB, md.Trajectory) and strcmp(metric, RMSD) == 0):
+        return _cdist_rmsd(XA, XB)
+
+    if not (isinstance(XA, np.ndarray) and isinstance(XB, np.ndarray)):
+        raise TypeError('TODO')
+    if metric not in VECTOR_METRICS:
+        raise ValueError('metric must be one of %s' %
+                         ', '.join("'%s'" % s for s in VECTOR_METRICS))
+
+    if XA.dtype == np.float64 and XB.dtype == np.float64:
+        return _cdist_double(XA, XB, metric)
+    elif XA.dtype == np.float32 and XB.dtype == np.float32:
+        return _cdist_float(XA, XB, metric)
+    else:
+        raise TypeError('XA and XB must be identically float32 or float64')
 
 
 def pdist(X, const char* metric, npy_intp[::1] X_indices=None):
@@ -354,6 +409,59 @@ cdef _assign_nearest_float(float[:, ::1] X, float[:, ::1] Y,
         X.shape[0], Y.shape[0], n_features, length,
         &assignments[0])
     return np.array(assignments, copy=False), inertia
+
+
+cdef _cdist_rmsd(XA, XB):
+    cdef npy_intp i, j
+    cdef float[:, :, ::1] XA_xyz = XA.xyz
+    cdef float[:, :, ::1] XB_xyz = XB.xyz
+    cdef npy_intp XA_length = XA_xyz.shape[0]
+    cdef npy_intp XB_length = XB_xyz.shape[0]
+    cdef int n_atoms = XA_xyz.shape[1]
+    cdef float[::1] XA_trace, XB_trace
+    cdef double[:, ::1] out
+
+    if XA._rmsd_traces is None:
+        raise ValueError('XA must be pre-centered using '
+                         'md.Trajectory.center_coordinates')
+    if XB._rmsd_traces is None:
+        raise ValueError('XB must be pre-centered using '
+                         'md.Trajectory.center_coordinates')
+
+    if XA_xyz.shape[1] != XB_xyz.shape[1]:
+        raise ValueError('XA and XB must have the same number of atoms')
+
+    XA_trace = XA._rmsd_traces
+    XB_trace = XB._rmsd_traces
+
+    out = np.zeros((XA_length, XB_length), dtype=np.double)
+
+    for i in range(XA_length):
+        for j in range(XB_length):
+            rmsd = sqrt(msd_atom_major(n_atoms, n_atoms, &XA_xyz[i,0,0],
+                        &XB_xyz[j,0,0], XA_trace[i], XB_trace[j], 0, NULL))
+            out[i,j] = rmsd
+
+    return np.array(out, copy=False)
+
+
+cdef _cdist_double(double[:, ::1] XA, double[:, ::1] XB, const char* metric):
+    cdef double[:, ::1] out
+    if XA.shape[1] != XB.shape[1]:
+        raise ValueError('XA and XB must have the same number of columns')
+    out = np.zeros((XA.shape[0], XB.shape[0]), dtype=np.double)
+    cdist_double(&XA[0,0], &XB[0,0], metric, XA.shape[0], XB.shape[0],
+                    XA.shape[1], &out[0,0])
+    return np.array(out, copy=False)
+
+cdef _cdist_float(float[:, ::1] XA, float[:, ::1] XB, const char* metric):
+    cdef double[:, ::1] out
+    if XA.shape[1] != XB.shape[1]:
+        raise ValueError('XA and XB must have the same number of columns')
+    out = np.zeros((XA.shape[0], XB.shape[0]), dtype=np.double)
+    cdist_float(&XA[0,0], &XB[0,0], metric, XA.shape[0], XB.shape[0],
+                    XA.shape[1], &out[0,0])
+    return np.array(out, copy=False)
 
 
 cdef _pdist_rmsd(X, npy_intp[::1] X_indices=None):

--- a/msmbuilder/libdistance/libdistance.pyx
+++ b/msmbuilder/libdistance/libdistance.pyx
@@ -168,7 +168,7 @@ def cdist(XA, XB, const char* metric):
         return _cdist_rmsd(XA, XB)
 
     if not (isinstance(XA, np.ndarray) and isinstance(XB, np.ndarray)):
-        raise TypeError('TODO')
+        raise TypeError('XA and XB must be numpy arrays')
     if metric not in VECTOR_METRICS:
         raise ValueError('metric must be one of %s' %
                          ', '.join("'%s'" % s for s in VECTOR_METRICS))

--- a/msmbuilder/libdistance/libdistance.pyx
+++ b/msmbuilder/libdistance/libdistance.pyx
@@ -420,11 +420,9 @@ cdef _cdist_rmsd(XA, XB):
     cdef double[:, ::1] out
 
     if XA._rmsd_traces is None:
-        raise ValueError('XA must be pre-centered using '
-                         'md.Trajectory.center_coordinates')
+        XA.center_coordinates()
     if XB._rmsd_traces is None:
-        raise ValueError('XB must be pre-centered using '
-                         'md.Trajectory.center_coordinates')
+        XB.center_coordinates()
 
     if XA_xyz.shape[1] != XB_xyz.shape[1]:
         raise ValueError('XA and XB must have the same number of atoms')

--- a/msmbuilder/libdistance/src/cdist.hpp
+++ b/msmbuilder/libdistance/src/cdist.hpp
@@ -1,0 +1,49 @@
+#include "distance_kernels.h"
+
+
+void cdist_double(const double* XA, const double* XB, const char* metric,
+                  npy_intp na, npy_intp nb, npy_intp m, double* out)
+
+{
+    npy_intp i, j, k;
+    const double *u, *v;
+    double (*metricfunc) (const double *u, const double *v, npy_intp n) = \
+            metric_double(metric);
+    if (metricfunc == NULL) {
+        fprintf(stderr, "Error");
+        return;
+    }
+
+    k = 0;
+    for (i = 0; i < na; i++) {
+        for (j = 0; j < nb; j++) {
+            u = XA + m * i;
+            v = XB + m * j;
+            out[k++] = metricfunc(u, v, m);
+        }
+    }
+}
+
+
+void cdist_float(const float* XA, const float* XB, const char* metric,
+                  npy_intp na, npy_intp nb, npy_intp m, double* out)
+
+{
+    npy_intp i, j, k;
+    const float *u, *v;
+    double (*metricfunc) (const float *u, const float *v, npy_intp n) = \
+            metric_float(metric);
+    if (metricfunc == NULL) {
+        fprintf(stderr, "Error");
+        return;
+    }
+
+    k = 0;
+    for (i = 0; i < na; i++) {
+        for (j = 0; j < nb; j++) {
+            u = XA + m * i;
+            v = XB + m * j;
+            out[k++] = metricfunc(u, v, m);
+        }
+    }
+}

--- a/msmbuilder/tests/test_libdistance.py
+++ b/msmbuilder/tests/test_libdistance.py
@@ -3,7 +3,7 @@ import sys
 import numpy as np
 import mdtraj as md
 import scipy.spatial.distance
-from msmbuilder.libdistance import assign_nearest, pdist, dist, sumdist
+from msmbuilder.libdistance import assign_nearest, cdist, pdist, dist, sumdist
 from msmbuilder.example_datasets import AlanineDipeptide
 
 random = np.random.RandomState()
@@ -37,16 +37,16 @@ def test_assign_nearest_double_float_1():
             assert isinstance(assignments, np.ndarray)
             assert isinstance(inertia, float)
 
-            cdist = scipy.spatial.distance.cdist(X, Y, metric=metric)
-            assert cdist.shape == (10, 3)
+            cdist_1 = cdist(X, Y, metric=metric)
+            assert cdist_1.shape == (10, 3)
             f = lambda: np.testing.assert_array_equal(
                 assignments,
-                cdist.argmin(axis=1))
+                cdist_1.argmin(axis=1))
             f.description = 'assign_nearest: %s %s' % (metric, X.dtype)
 
             yield lambda: np.testing.assert_almost_equal(
                 inertia,
-                cdist[np.arange(10), assignments].sum(),
+                cdist_1[np.arange(10), assignments].sum(),
                 decimal=5 if X.dtype == np.float32 else 10)
 
 
@@ -63,13 +63,13 @@ def test_assign_nearest_float_double_2():
             assert isinstance(assignments, np.ndarray)
             assert isinstance(inertia, float)
 
-            cdist = scipy.spatial.distance.cdist(X[X_indices], Y, metric=metric)
+            cdist_1 = cdist(X[X_indices], Y, metric=metric)
             yield lambda: np.testing.assert_array_equal(
                 assignments,
-                cdist.argmin(axis=1))
+                cdist_1.argmin(axis=1))
             yield lambda: np.testing.assert_almost_equal(
                 inertia,
-                cdist[np.arange(5), assignments].sum(),
+                cdist_1[np.arange(5), assignments].sum(),
                 decimal=5 if X.dtype == np.float32 else 10)
 
 
@@ -79,16 +79,16 @@ def test_assign_nearest_rmsd_1():
     assert isinstance(assignments, np.ndarray)
     assert isinstance(inertia, float)
 
-    cdist = np.array([md.rmsd(X_rmsd, Y_rmsd[i], precentered=True) for i in range(len(Y_rmsd))]).T
-    assert cdist.shape == (10, 3)
+    cdist_rmsd = cdist(X_rmsd, Y_rmsd, 'rmsd')
+    assert cdist_rmsd.shape == (10, 3)
 
     np.testing.assert_array_equal(
         assignments,
-        cdist.argmin(axis=1))
+        cdist_rmsd.argmin(axis=1))
 
     np.testing.assert_almost_equal(
         inertia,
-        cdist[np.arange(10), assignments].sum(),
+        cdist_rmsd[np.arange(10), assignments].sum(),
         decimal=6)
 
 
@@ -98,18 +98,30 @@ def test_assign_nearest_rmsd_2():
     assert isinstance(assignments, np.ndarray)
     assert isinstance(inertia, float)
 
-    cdist = np.array([md.rmsd(X_rmsd, Y_rmsd[i], precentered=True) for i in range(len(Y_rmsd))]).T
-    cdist = cdist[X_indices].astype(np.double)
-    assert cdist.shape == (5, 3)
+    cdist_rmsd = cdist(X_rmsd, Y_rmsd, 'rmsd')
+    cdist_rmsd = cdist_rmsd[X_indices].astype(np.double)
+    assert cdist_rmsd.shape == (5, 3)
 
     np.testing.assert_array_equal(
         assignments,
-        cdist.argmin(axis=1))
+        cdist_rmsd.argmin(axis=1))
 
     np.testing.assert_almost_equal(
         inertia,
-        cdist[np.arange(5), assignments].sum(),
+        cdist_rmsd[np.arange(5), assignments].sum(),
         decimal=5)
+
+
+def test_cdist_double_float_1():
+    # test without X_indices
+    for metric in VECTOR_METRICS:
+        for X, Y in ((X_double, Y_double), (X_float, Y_float)):
+            cdist_1 = cdist(X, Y, metric)
+            cdist_2 = scipy.spatial.distance.cdist(X, Y, metric)
+            yield lambda : np.testing.assert_almost_equal(
+                cdist_1,
+                cdist_2,
+                decimal=5 if X.dtype == np.float32 else 10)
 
 
 def test_pdist_double_float_1():
@@ -125,7 +137,7 @@ def test_pdist_double_float_1():
 
 
 def test_pdist_double_float_2():
-    # test without X_indices
+    # test with X_indices
     for metric in VECTOR_METRICS:
         for X, Y in ((X_double, Y_double), (X_float, Y_float)):
             pdist_1 = pdist(X, metric, X_indices=X_indices)
@@ -134,6 +146,12 @@ def test_pdist_double_float_2():
                 pdist_1,
                 pdist_2,
                 decimal=5 if X.dtype == np.float32 else 10)
+
+
+def test_cdist_rmsd_1():
+    got = cdist(X_rmsd, Y_rmsd, "rmsd")
+    all2all = np.array([md.rmsd(X_rmsd, Y_rmsd[i], precentered=True) for i in range(len(Y_rmsd))]).T
+    np.testing.assert_almost_equal(got, all2all, decimal=5)
 
 
 def test_pdist_rmsd_1():
@@ -158,7 +176,7 @@ def test_dist_double_float_1():
     for metric in VECTOR_METRICS:
         for X, Y in ((X_double, Y_double), (X_float, Y_float)):
             dist_1 = dist(X, Y[0], metric)
-            dist_2 = scipy.spatial.distance.cdist(X, [Y[0]], metric)[:,0]
+            dist_2 = cdist(X, Y, metric)[:,0]
             yield lambda : np.testing.assert_almost_equal(
                 dist_1,
                 dist_2,
@@ -170,7 +188,7 @@ def test_dist_double_float_2():
     for metric in VECTOR_METRICS:
         for X, Y in ((X_double, Y_double), (X_float, Y_float)):
             dist_1 = dist(X, Y[0], metric, X_indices)
-            dist_2 = scipy.spatial.distance.cdist(X, [Y[0]], metric)[X_indices,0]
+            dist_2 = cdist(X, Y, metric)[X_indices,0]
             yield lambda : np.testing.assert_almost_equal(
                 dist_1,
                 dist_2,
@@ -218,11 +236,11 @@ def test_canberra_32_1():
         Y = X[[0,1,2], :]
 
         assignments, inertia = assign_nearest(X, Y, 'canberra')
-        cdist = scipy.spatial.distance.cdist(X, Y, metric='canberra')
-        ref = cdist.argmin(axis=1)
+        cdist_can = cdist(X, Y, metric='canberra')
+        ref = cdist_can.argmin(axis=1)
         if not np.all(ref == assignments):
             different = np.where(assignments != ref)[0]
-            row = cdist[different, :]
+            row = cdist_can[different, :]
 
             # if there are differences between assignments and the 'reference',
             # make sure that there is actually some difference between the
@@ -239,11 +257,11 @@ def test_canberra_32_2():
         X_indices = random.random_integers(low=0, high=9, size=5).astype(np.intp)
 
         assignments, inertia = assign_nearest(X, Y, 'canberra', X_indices=X_indices)
-        cdist = scipy.spatial.distance.cdist(X[X_indices], Y, metric='canberra')
-        ref = cdist.argmin(axis=1)
+        cdist_can = cdist(X[X_indices], Y, metric='canberra')
+        ref = cdist_can.argmin(axis=1)
         if not np.all(ref == assignments):
             different = np.where(assignments != ref)[0]
-            row = cdist[different, :]
+            row = cdist_can[different, :]
 
             # if there are differences between assignments and the 'reference',
             # make sure that there is actually some difference between the

--- a/msmbuilder/tests/test_strucrmsdfeaturizer.py
+++ b/msmbuilder/tests/test_strucrmsdfeaturizer.py
@@ -1,0 +1,45 @@
+import msmbuilder.featurizer
+from msmbuilder.example_datasets import fetch_alanine_dipeptide
+
+def test_alanine_dipeptide():
+    # This test takes the rmsd of the 0th set of alanine dipeptide
+    # trajectories relative to the 0th frame of the dataset.
+    # The test asserts that the first rmsd calculated will be zero.
+
+    dataset = fetch_alanine_dipeptide()
+    trajectories = dataset["trajectories"]
+    featurizer = msmbuilder.featurizer.StrucRMSDFeaturizer(
+        trajectories[0], trajectories[0][0], range(trajectories[0].n_atoms))
+    data = featurizer.transform(trajectories[0])
+
+    assert(data[0] < 1e-3)
+    # For some reason the rmsd of trajectories[0][0] with itself
+    # is 0.0001041; see
+    #
+    #  $ ipython
+    #  >>> import mdtraj as md
+    #  >>> import msmbuilder.featurizer
+    #  >>> from msmbuilder.example_datasets import fetch_alanine_dipeptide
+    #  >>> dataset = fetch_alanine_dipeptide()
+    #  >>> trajectories = dataset["trajectories"]
+    #  >>> md.rmsd(trajectories[0][0],trajectories[0][0],0)
+
+
+def test_two_refs():
+    # This test uses the 0th and 1st frames of the 0th set of
+    # adp trajectories as the two reference trajectories and
+    # ensures that the rmsd of the 0th frame of the dataset with
+    # the 0th reference are identical and the 1st frame of the
+    # dataset with the 1st reference are identical.
+
+    dataset = fetch_alanine_dipeptide()
+    trajectories = dataset["trajectories"]
+    featurizer = msmbuilder.featurizer.StrucRMSDFeaturizer(
+        trajectories[0], trajectories[0][0:2], range(trajectories[0].n_atoms))
+    data = featurizer.transform(trajectories[0])
+
+    # TODO: Figure out why arrays are 3D
+    assert(data[0][0][0] - data[1][0][1] < 1e-3)
+    assert(data[1][0][0] - data[0][0][1] < 1e-3)
+
+


### PR DESCRIPTION
As discussed with @mpharrigan this pull request attempts to create a featurizer which inputs a trajectory to be analyzed ("traj") and a reference trajectory ("ref") and outputs the RMSD of each frame of traj with respect to each frame in ref. The intended output is a numpy array with n_rows = traj.n_frames and n_columns = ref.n_frames. I have also included tests for ref.n_frames = 1 and ref.n_frames = 2.

Question - I don't think my python in the featurizer code is elegant. I want to output an array as specified above but it seems to output a list that corresponds to a 3D array with one extra/meaningless dimension. Upon fixing this we must also fix the second test in tests/test_strucrmsdfeaturizer.py; see TODO.

cc: @rmcgibbo @cxhernandez 