### PR TITLE
Use tuples of ints as keys to dataset objects

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,10 @@ API Changes
 New Features
 ~~~~~~~~~~~~
 
+- The NumpyDirDataset can accept tuples of integers as keys, and will create
+  a directory structure as appropriate. `ds[9752, 0, 1] = np.array()` will
+  put a file called `000000001.npy` under the directory `dsname/09752/00000/`
+
 
 Improvements
 ~~~~~~~~~~~~

--- a/msmbuilder/dataset.py
+++ b/msmbuilder/dataset.py
@@ -166,7 +166,7 @@ class _BaseDataset(Sequence):
         estimator
             The fit estimator.
         """
-        estimator.fit(self)
+        estimator.fit(self[:])
         return estimator
 
     def transform_with(self, estimator, out_ds, fmt=None):

--- a/msmbuilder/dataset.py
+++ b/msmbuilder/dataset.py
@@ -320,11 +320,13 @@ class NumpyDirDataset(_BaseDataset):
             filename = join(self.path, *[self.inter_fmt.format(index=i)
                                          for i in index[:-1]])
             i = index[-1]
-            try:
-                os.makedirs(filename)
-            except OSError as e:
-                if e.errno != errno.EEXIST:
-                    raise
+
+            if make_dirs:
+                try:
+                    os.makedirs(filename)
+                except OSError as e:
+                    if e.errno != errno.EEXIST:
+                        raise
         except TypeError:
             filename = self.path
             i = index

--- a/msmbuilder/tests/test_dataset.py
+++ b/msmbuilder/tests/test_dataset.py
@@ -355,3 +355,24 @@ def test_nesting_somelevels():
             for i, (k, v) in enumerate(ds.items()):
                 assert k == keys[i]
                 np.testing.assert_array_equal(ds[k], v)
+
+
+def test_no_dir_creation_on_read():
+    xx = np.random.randn(10, 1)
+    with tempdir():
+        with dataset('ds', 'w', fmt='dir-npy') as ds:
+
+            ds[0, 1, 2] = xx
+
+        with dataset('ds') as ds:
+            np.testing.assert_array_equal(xx, ds[0, 1, 2])
+
+            try:
+                # doesn't exist
+                yy = ds[1, 2, 3]
+            except:
+                pass
+
+            assert os.path.isdir("ds/00000/00001")
+            assert not os.path.exists("ds/00001")
+            assert not os.path.exists("ds/00001/00002")

--- a/msmbuilder/tests/test_dataset.py
+++ b/msmbuilder/tests/test_dataset.py
@@ -237,3 +237,71 @@ def test_items():
         np.testing.assert_array_equal(ds[:][2], ds[5])
 
         ds.close()
+
+
+def test_nesting_1():
+    with tempdir():
+        with dataset('ds', 'w', fmt='dir-npy') as ds:
+            ds[0, 0, 1] = np.random.randn(10, 1)
+            ds[0, 0, 2] = np.random.randn(10, 2)
+            ds[0, 1, 83] = np.random.randn(10, 3)
+
+            keys = [
+                (0, 0, 1),
+                (0, 0, 2),
+                (0, 1, 83),
+            ]
+
+            for i, (k, v) in enumerate(ds.items()):
+                assert k == keys[i]
+                np.testing.assert_array_equal(ds[k], v)
+
+            os.path.isdir("ds/00000/00000")
+            os.path.isdir("ds/00000/00001")
+            os.path.isfile("ds/00000/00000/00000083.npy")
+
+
+def test_nesting_2():
+    with tempdir():
+        with dataset('ds', 'w', fmt='dir-npy') as ds:
+            ds[0, 1] = np.random.randn(10, 1)
+            ds[0, 2] = np.random.randn(10, 2)
+            ds[1, 83] = np.random.randn(10, 3)
+
+            keys = [
+                (0, 1),
+                (0, 2),
+                (1, 83),
+            ]
+
+            for i, (k, v) in enumerate(ds.items()):
+                assert k == keys[i]
+                np.testing.assert_array_equal(ds[k], v)
+
+            for i, (k, v) in enumerate(ds[:]):
+                assert k == keys[i]
+                np.testing.assert_array_equal(ds[k], v)
+
+            os.path.isdir("ds/00000")
+            os.path.isdir("ds/00001")
+            os.path.isfile("ds/00000/00000083.npy")
+
+
+def test_nesting_sort():
+    with tempdir():
+        with dataset('ds', 'w', fmt='dir-npy') as ds:
+            ds[0, 0, 1] = np.random.randn(10, 1)
+            ds[0, 1, 83] = np.random.randn(10, 3)
+            ds[0, 1, 82] = np.random.randn(10, 3)
+            ds[0, 0, 2] = np.random.randn(10, 2)
+
+            keys = [
+                (0, 0, 1),
+                (0, 0, 2),
+                (0, 1, 82),
+                (0, 1, 83),
+            ]
+
+            for i, (k, v) in enumerate(ds.items()):
+                assert k == keys[i]
+                np.testing.assert_array_equal(ds[k], v)

--- a/msmbuilder/tests/test_dataset.py
+++ b/msmbuilder/tests/test_dataset.py
@@ -192,7 +192,7 @@ def test_order_1():
         with dataset('ds1/', 'w', 'dir-npy') as ds1:
             for i in range(20):
                 ds1[i] = np.random.randn(10)
-            assert list(ds1.keys()) == list(range(20))
+            assert list(ds1.keys()) == list(range(20)), list(ds1.keys())
 
 
 def test_append_dirnpy():
@@ -278,9 +278,33 @@ def test_nesting_2():
                 assert k == keys[i]
                 np.testing.assert_array_equal(ds[k], v)
 
-            for i, (k, v) in enumerate(ds[:]):
-                assert k == keys[i]
-                np.testing.assert_array_equal(ds[k], v)
+            for i, v in enumerate(ds[:]):
+                np.testing.assert_array_equal(ds[keys[i]], v)
+
+            os.path.isdir("ds/00000")
+            os.path.isdir("ds/00001")
+            os.path.isfile("ds/00000/00000083.npy")
+
+
+def test_nesting_list():
+    with tempdir():
+        with dataset('ds', 'w', fmt='dir-npy') as ds:
+            ds[[0, 1]] = np.random.randn(10, 1)
+            ds[[0, 2]] = np.random.randn(10, 2)
+            ds[[1, 83]] = np.random.randn(10, 3)
+
+            keys = [
+                [0, 1],
+                [0, 2],
+                [1, 83],
+            ]
+
+            for i, (k, v) in enumerate(ds.items()):
+                assert k == tuple(keys[i])
+                np.testing.assert_array_equal(ds[keys[i]], v)
+
+            for i, v in enumerate(ds[:]):
+                np.testing.assert_array_equal(ds[keys[i]], v)
 
             os.path.isdir("ds/00000")
             os.path.isdir("ds/00001")
@@ -301,6 +325,32 @@ def test_nesting_sort():
                 (0, 1, 82),
                 (0, 1, 83),
             ]
+
+            for i, (k, v) in enumerate(ds.items()):
+                assert k == keys[i]
+                np.testing.assert_array_equal(ds[k], v)
+
+
+def test_nesting_somelevels():
+    with tempdir():
+        with dataset('ds', 'w', fmt='dir-npy') as ds:
+            ds[0] = np.random.randn(10, 1)
+            ds[0, 1] = np.random.randn(10, 1)
+            ds[0, 1, 2] = np.random.randn(10, 1)
+            ds[0, 1, 3] = np.random.randn(10, 3)
+            ds[0, 8, 2] = np.random.randn(10, 1)
+            ds[0, 8, 3] = np.random.randn(10, 3)
+
+            keys = [
+                0,
+                (0, 1),
+                (0, 1, 2),
+                (0, 1, 3),
+                (0, 8, 2),
+                (0, 8, 3),
+            ]
+
+            assert keys == list(ds.keys()), keys
 
             for i, (k, v) in enumerate(ds.items()):
                 assert k == keys[i]

--- a/msmbuilder/tests/test_dataset.py
+++ b/msmbuilder/tests/test_dataset.py
@@ -421,16 +421,16 @@ def test_nesting_nopad():
             assert os.path.isfile("ds/1/1/84.npy")
 
 
-def test_strict_filenames():
+def test_zero_pad():
     with tempdir():
         with dataset('ds', 'w', fmt='dir-npy') as ds:
             ds[0, 1] = np.random.randn(10, 1)
             ds[0, 2] = np.random.randn(10, 2)
 
-        with open("ds/00000/003.npy", 'w') as f:
-            f.write("I'm not actually a numpy files!")
+        with open("ds/00000/3.npy", 'w') as f:
+            f.write("I'm not actually a numpy file!")
 
-        with dataset('ds', strict_filenames=True) as ds:
+        with dataset('ds') as ds:
             keys = [
                 (0, 1),
                 (0, 2),
@@ -442,26 +442,20 @@ def test_strict_filenames():
 
             assert 'Unknown file' in str(w[0].message)
 
-        with dataset("ds") as ds:
-            keys = [
-                (0, 1),
-                (0, 2),
-                (0, 3),
-            ]
-            assert keys == list(ds.keys()), list(ds.keys())
+        with dataset("ds", zero_pad=False) as ds:
+            with warnings.catch_warnings(record=True) as w:
+                assert list(ds.keys()) == [], list(ds.keys())
 
-            with assert_raises(IndexError):
-                x = ds[0, 3]
-                xx = list(ds)
+            assert "Unknown directory" in str(w[0].message)
 
 
-def test_loose_filenames():
+def test_no_padding():
     with tempdir():
         with dataset('ds', 'w', fmt='dir-npy', zero_pad=False) as ds:
             ds[0, 1] = np.random.randn(10, 1)
             ds[0, 2] = np.random.randn(10, 2)
 
-        with dataset('ds') as ds:
+        with dataset('ds', zero_pad=False) as ds:
             keys = [
                 (0, 1),
                 (0, 2),


### PR DESCRIPTION
Right now only the dir-npy dataset, lets you do stuff like this:

```python
ds[9752, 5, 1] = np.array()
```

```bash
ls datasetname/09752/00005/00001.npy
```

Which is nicer for organizing fah-style data.

It should only be used with integers [or things formattable by `"{:d}"` and sortable]

I'm thinking of adding a flag to disable 0-padding of the filenames. The sorting should be done with the regular-expressioned integer values anyways.