### PR TITLE
fix bootstrap slowness 

### DIFF
--- a/msmbuilder/msm/validation/bootstrapmsm.py
+++ b/msmbuilder/msm/validation/bootstrapmsm.py
@@ -215,7 +215,6 @@ def _fit_one(jt):
     try:
         mdl.fit(sequences)
         # solve the eigensystem
-        mdl.eigenvalues_[0]
     except ValueError:
         mdl = None
         warnings.warn("One of the MSMs fitting "


### PR DESCRIPTION
 - [x] Implement feature / fix bug
 - [ ] Add tests
 - [ ] Update changelog

Based upon what i saw on real data and raised in #745 . Current hypothesis is that that eigensolver is slowing things down. The ```_parallel_fit``` command should trigger the eigensolver sequentially any how as it tries to map the perturbed populations back to the mle solution. 