### PR TITLE
added appreciation for Andrey Markov

### DIFF
--- a/msmbuilder/msm/markov_appreciation.py
+++ b/msmbuilder/msm/markov_appreciation.py
@@ -1,0 +1,17 @@
+# Author: Muneeb Sultan <msultan@stanford.edu>
+# Contributors:
+# Copyright (c) 2014, Stanford University
+# All rights reserved.
+
+#-----------------------------------------------------------------------------
+# Imports
+#-----------------------------------------------------------------------------
+
+from PIL import Image
+import requests
+from io import BytesIO
+def show_markov_appreciation():
+    response = requests.get("https://upload.wikimedia.org/wikipedia/commons/"
+                            "thumb/7/70/AAMarkov.jpg/330px-AAMarkov.jpg")
+    img = Image.open(BytesIO(response.content))
+    img.show()


### PR DESCRIPTION
I noticed that msmbuilder currently doesn't appreciate [Andrey Markov](https://en.wikipedia.org/wiki/Andrey_Markov) enough. This PR attempts to fix this by adding a markov_appreciation module to msmbuilder. 

Currently only works for py3. 
