### PR TITLE
cutoff option for contact featurizer

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,11 @@ API Changes
 New Features
 ~~~~~~~~~~~~
 
+ - ``BinaryContactFeaturizer`` featurizes a trajectory into a
+    boolean array corresponding to whether each residue-residue
+    distance is below a cutoff (#798).
+ - ``LogisticContactFeaturizer`` produces a logistic transform
+    of residue-residue distances about a center distance (#798).
 
 Improvements
 ~~~~~~~~~~~~
@@ -109,7 +114,7 @@ New Features
 - ``VonMisesFeaturizer`` uses soft bins around the unit-circle to give an
   alternate representation of dihedral angles (#744).
 - ``MarkovStateModel`` has a ``partial_transform()`` method (#707).
-- ``KapaAngleFeaturizer`` is available via the command line (#681).
+- ``KappaAngleFeaturizer`` is available via the command line (#681).
 - ``MarkovStateModel`` has a new attribute, ``percent_retained_``, for
   ergodic trimming (#689).
 - ``AlphaAngleFeaturizer`` computes the dihedral angles between alpha

--- a/msmbuilder/cluster/kcenters.py
+++ b/msmbuilder/cluster/kcenters.py
@@ -1,6 +1,6 @@
 # Author: Robert McGibbon <rmcgibbo@gmail.com>
-# Contributors:
-# Copyright (c) 2014, Stanford University
+# Contributors: Brooke Husic <brookehusic@gmail.com>
+# Copyright (c) 2016, Stanford University
 # All rights reserved.
 
 #-----------------------------------------------------------------------------
@@ -77,6 +77,9 @@ class _KCenters(ClusterMixin, TransformerMixin):
         self.random_state = random_state
 
     def fit(self, X, y=None):
+        if isinstance(X, np.ndarray):
+            if not (X.dtype == 'float32' or X.dtype == 'float64'):
+                X = X.astype('float64')
         n_samples = len(X)
         new_center_index = check_random_state(self.random_state).randint(0, n_samples)
 
@@ -115,6 +118,9 @@ class _KCenters(ClusterMixin, TransformerMixin):
         Y : array, shape [n_samples,]
             Index of the closest center each sample belongs to.
         """
+        if isinstance(X, np.ndarray):
+            if not (X.dtype == 'float32' or X.dtype == 'float64'):
+                X = X.astype('float64')
         labels, inertia = libdistance.assign_nearest(
             X, self.cluster_centers_, metric=self.metric)
         return labels

--- a/msmbuilder/cluster/kmedoids.py
+++ b/msmbuilder/cluster/kmedoids.py
@@ -1,6 +1,6 @@
 # Author: Robert McGibbon <rmcgibbo@gmail.com>
-# Contributors:
-# Copyright (c) 2014, Stanford University
+# Contributors: Brooke Husic <brookehusic@gmail.com>
+# Copyright (c) 2016, Stanford University
 # All rights reserved.
 
 #-----------------------------------------------------------------------------
@@ -85,6 +85,9 @@ class _KMedoids(ClusterMixin, TransformerMixin):
             raise ValueError('n_passes must be greater than 0. got %s' %
                              self.n_clusters)
 
+        if isinstance(X, np.ndarray):
+            if not (X.dtype == 'float32' or X.dtype == 'float64'):
+                X = X.astype('float64')
         dmat = libdistance.pdist(X, metric=self.metric)
         ids, self.inertia_, _ = _kmedoids.kmedoids(
             self.n_clusters, dmat, self.n_passes,
@@ -114,6 +117,9 @@ class _KMedoids(ClusterMixin, TransformerMixin):
         Y : array, shape [n_samples,]
             Index of the closest center each sample belongs to.
         """
+        if isinstance(X, np.ndarray):
+            if not (X.dtype == 'float32' or X.dtype == 'float64'):
+                X = X.astype('float64')
         labels, inertia = libdistance.assign_nearest(
             X, self.cluster_centers_, metric=self.metric)
         return labels

--- a/msmbuilder/cluster/minibatchkmedoids.py
+++ b/msmbuilder/cluster/minibatchkmedoids.py
@@ -1,6 +1,6 @@
 # Author: Robert McGibbon <rmcgibbo@gmail.com>
-# Contributors:
-# Copyright (c) 2014, Stanford University
+# Contributors: Brooke Husic <brookehusic@gmail.com>
+# Copyright (c) 2016, Stanford University
 # All rights reserved.
 
 #-----------------------------------------------------------------------------
@@ -88,6 +88,9 @@ class _MiniBatchKMedoids(ClusterMixin, TransformerMixin):
         self.random_state = random_state
 
     def fit(self, X, y=None):
+        if isinstance(X, np.ndarray):
+            if not (X.dtype == 'float32' or X.dtype == 'float64'):
+                X = X.astype('float64')
         n_samples = len(X)
         n_batches = int(np.ceil(float(n_samples) / self.batch_size))
         n_iter = int(self.max_iter * n_batches)
@@ -156,6 +159,9 @@ class _MiniBatchKMedoids(ClusterMixin, TransformerMixin):
         Y : array, shape [n_samples,]
             Index of the closest center each sample belongs to.
         """
+        if isinstance(X, np.ndarray):
+            if not (X.dtype == 'float32' or X.dtype == 'float64'):
+                X = X.astype('float64')
         labels, inertia = libdistance.assign_nearest(
             X, self.cluster_centers_, metric=self.metric)
         return labels

--- a/msmbuilder/commands/__init__.py
+++ b/msmbuilder/commands/__init__.py
@@ -2,7 +2,8 @@ from __future__ import absolute_import
 from .featurizer import (AtomPairsFeaturizerCommand, ContactFeaturizerCommand,
                          DihedralFeaturizerCommand, DRIDFeaturizerCommand,
                          SuperposeFeaturizerCommand, KappaAngleFeaturizerCommand,
-                         AlphaAngleFeaturizerCommand, RMSDFeaturizerCommand)
+                         AlphaAngleFeaturizerCommand, RMSDFeaturizerCommand,
+                         BinaryContactFeaturizerCommand, LogisticContactFeaturizerCommand)
 from .fit import GaussianHMMCommand
 from .fit_transform import KMeansCommand, KCentersCommand
 from .transform import TransformCommand

--- a/msmbuilder/commands/featurizer.py
+++ b/msmbuilder/commands/featurizer.py
@@ -13,7 +13,8 @@ from ..featurizer import (AtomPairsFeaturizer, SuperposeFeaturizer,
                           DRIDFeaturizer, DihedralFeaturizer,
                           ContactFeaturizer, GaussianSolventFeaturizer,
                           KappaAngleFeaturizer, AlphaAngleFeaturizer,
-                          RMSDFeaturizer)
+                          RMSDFeaturizer, BinaryContactFeaturizer,
+                          LogisticContactFeaturizer)
 
 
 class FeaturizerCommand(NumpydocClassCommand):
@@ -72,7 +73,7 @@ class FeaturizerCommand(NumpydocClassCommand):
         print("  >>> from msmbuilder.dataset import dataset")
         print("  >>> ds = dataset('%s')\n" % self.transformed)
 
-        if self.out is not '':
+        if self.out != '':
             verbosedump(self.instance, self.out)
             print("To load this %s object interactively inside an IPython\n"
                   "shell or notebook, run: \n" % self.klass.__name__)
@@ -164,7 +165,27 @@ class ContactFeaturizerCommand(FeaturizerCommand):
     klass = ContactFeaturizer
 
     def _contacts_type(self, val):
-        if val is 'all':
+        if val == 'all':
+            return val
+        else:
+            return np.loadtxt(val, dtype=int, ndmin=2)
+
+class BinaryContactFeaturizerCommand(FeaturizerCommand):
+    _concrete = True
+    klass = BinaryContactFeaturizer
+
+    def _contacts_type(self, val):
+        if val == 'all':
+            return val
+        else:
+            return np.loadtxt(val, dtype=int, ndmin=2)
+
+class LogisticContactFeaturizerCommand(FeaturizerCommand):
+    _concrete = True
+    klass = LogisticContactFeaturizer
+
+    def _contacts_type(self, val):
+        if val == 'all':
             return val
         else:
             return np.loadtxt(val, dtype=int, ndmin=2)

--- a/msmbuilder/featurizer/featurizer.py
+++ b/msmbuilder/featurizer/featurizer.py
@@ -853,7 +853,7 @@ class SASAFeaturizer(Featurizer):
 
 
 class ContactFeaturizer(Featurizer):
-    """Featurizer based on residue-residue distances
+    """Featurizer based on residue-residue distances.
 
     This featurizer transforms a dataset containing MD trajectories into
     a vector dataset by representing each frame in each of the MD trajectories
@@ -891,10 +891,12 @@ class ContactFeaturizer(Featurizer):
         self.scheme = scheme
         self.ignore_nonprotein = ignore_nonprotein
 
+    def _transform(self, distances):
+        return distances
 
     def partial_transform(self, traj):
-        """Featurize an MD trajectory into a vector space via of residue-residue
-        distances
+        """Featurize an MD trajectory into a vector space derived from
+        residue-residue distances
 
         Parameters
         ----------
@@ -913,9 +915,10 @@ class ContactFeaturizer(Featurizer):
         --------
         transform : simultaneously featurize a collection of MD trajectories
         """
+
         distances, _ = md.compute_contacts(traj, self.contacts,
                                            self.scheme, self.ignore_nonprotein)
-        return distances
+        return self._transform(distances)
 
 
     def describe_features(self, traj):
@@ -962,6 +965,117 @@ class ContactFeaturizer(Featurizer):
         feature_descs.extend(dict_maker(zippy))
 
         return feature_descs
+
+
+class BinaryContactFeaturizer(ContactFeaturizer):
+    """Featurizer based on residue-residue contacts below a cutoff.
+
+    This featurizer transforms a dataset containing MD trajectories into
+    a vector dataset by representing each frame in each of the MD trajectories
+    by a vector of the binary contacts between pairs of amino-acid residues.
+
+    The exact method for computing the the distance between two residues
+    is configurable with the ``scheme`` parameter.
+
+    Parameters
+    ----------
+    contacts : np.ndarray or 'all'
+        array containing (0-indexed) indices of the residues to compute the
+        contacts for. (e.g. np.array([[0, 10], [0, 11]]) would compute
+        the contact between residue 0 and residue 10 as well as
+        the contact between residue 0 and residue 11.) [NOTE: if no
+        array is passed then 'all' contacts are calculated. This means
+        that the result will contain all contacts between residues
+        separated by at least 3 residues.]
+    scheme : {'ca', 'closest', 'closest-heavy'}
+        scheme to determine the distance between two residues:
+            'ca' : distance between two residues is given by the distance
+                between their alpha carbons
+            'closest' : distance is the closest distance between any
+                two atoms in the residues
+            'closest-heavy' : distance is the closest distance between
+                any two non-hydrogen atoms in the residues
+    ignore_nonprotein : bool
+        When using `contact==all`, don't compute contacts between
+        "residues" which are not protein (i.e. do not contain an alpha
+        carbon).
+    cutoff : float, default=0.8
+        Distances shorter than CUTOFF [nm] are returned as '1' and
+        distances longer than CUTOFF are returned as '0'.
+    """
+
+    def __init__(self, contacts='all', scheme='closest-heavy', ignore_nonprotein=True, cutoff=0.8):
+        super(BinaryContactFeaturizer, self).__init__(contacts=contacts, scheme=scheme,
+                                                    ignore_nonprotein=ignore_nonprotein)
+        if cutoff < 0:
+            raise ValueError('cutoff must be a positive distance [nm]')
+        self.cutoff = cutoff
+
+    def _transform(self, distances):
+        return distances < self.cutoff
+
+
+class LogisticContactFeaturizer(ContactFeaturizer):
+    """Featurizer based on logistic-transformed residue-residue contacts.
+
+    This featurizer transforms a dataset containing MD trajectories into
+    a vector dataset by representing each frame in each of the MD trajectories
+    by a vector of the distances between pairs of amino-acid residues transformed
+    by the logistic function (reflected across the x axis):
+
+    result = [1 + exp(k*(distances - cutoff))]^-1
+
+    The exact method for computing the the distance between two residues
+    is configurable with the ``scheme`` parameter.
+
+    Parameters
+    ----------
+    contacts : np.ndarray or 'all'
+        array containing (0-indexed) indices of the residues to compute the
+        contacts for. (e.g. np.array([[0, 10], [0, 11]]) would compute
+        the contact between residue 0 and residue 10 as well as
+        the contact between residue 0 and residue 11.) [NOTE: if no
+        array is passed then 'all' contacts are calculated. This means
+        that the result will contain all contacts between residues
+        separated by at least 3 residues.]
+    scheme : {'ca', 'closest', 'closest-heavy'}
+        scheme to determine the distance between two residues:
+            'ca' : distance between two residues is given by the distance
+                between their alpha carbons
+            'closest' : distance is the closest distance between any
+                two atoms in the residues
+            'closest-heavy' : distance is the closest distance between
+                any two non-hydrogen atoms in the residues
+    ignore_nonprotein : bool
+        When using `contact==all`, don't compute contacts between
+        "residues" which are not protein (i.e. do not contain an alpha
+        carbon).
+    center : float, default=0.8
+        Determines the midpoint of the sigmoid, x_0, [nm]. Distances
+        shorter than CENTER will return values greater than 0.5 and
+        distances larger than CENTER will return values smaller than 0.5.
+    steepness : float, default=20
+        Determines the steepness of the logistic curve, [1/nm]. Small 
+        and large distances will approach ouput values of 1 and 0,
+        respectively, more quickly.
+    """
+
+
+    def __init__(self, contacts='all', scheme='closest-heavy', ignore_nonprotein=True,
+                                                            center=0.8, steepness=20):
+        super(LogisticContactFeaturizer, self).__init__(contacts=contacts, scheme=scheme,
+                                                    ignore_nonprotein=ignore_nonprotein)
+        if center < 0:
+            raise ValueError('center must be a positive distance [nm]')
+        if steepness < 0:
+            raise ValueError('steepness must be a positive inverse distance [1/nm]')
+
+        self.center = center
+        self.steepness = steepness
+
+    def _transform(self, distances):
+        result = 1.0/(1+np.exp(self.steepness*(distances-self.center)))
+        return result
 
 
 class GaussianSolventFeaturizer(Featurizer):

--- a/msmbuilder/tests/test_contactfeaturizers.py
+++ b/msmbuilder/tests/test_contactfeaturizers.py
@@ -1,0 +1,98 @@
+import mdtraj as md
+import numpy as np
+import warnings
+
+from msmbuilder.example_datasets import fetch_fs_peptide
+from msmbuilder.featurizer import ContactFeaturizer
+from msmbuilder.featurizer import BinaryContactFeaturizer
+from msmbuilder.featurizer import LogisticContactFeaturizer
+
+def test_contacts():
+    dataset = fetch_fs_peptide()
+    trajectories = dataset["trajectories"]
+    contactfeaturizer = ContactFeaturizer()
+    contacts = contactfeaturizer.transform([trajectories[0]])
+
+    assert contacts[0].shape[1] == 171
+
+
+def test_binaries():
+    dataset = fetch_fs_peptide()
+    trajectories = dataset["trajectories"]
+    binarycontactfeaturizer = BinaryContactFeaturizer()
+    binaries = binarycontactfeaturizer.transform([trajectories[0]])
+
+    assert binaries[0].shape[1] == 171
+    assert np.sum(binaries[0]) <= binaries[0].shape[0]*binaries[0].shape[1]
+
+
+def test_binaries_inf_cutoff():
+    dataset = fetch_fs_peptide()
+    trajectories = dataset["trajectories"]
+    binarycontactfeaturizer = BinaryContactFeaturizer(cutoff=1e10)
+    binaries = binarycontactfeaturizer.transform([trajectories[0]])
+
+    assert binaries[0].shape[1] == 171
+    assert np.sum(binaries[0]) == binaries[0].shape[0]*binaries[0].shape[1]
+
+
+def test_binaries_zero_cutoff():
+    dataset = fetch_fs_peptide()
+    trajectories = dataset["trajectories"]
+    binarycontactfeaturizer = BinaryContactFeaturizer(cutoff=0)
+    binaries = binarycontactfeaturizer.transform([trajectories[0]])
+
+    assert binaries[0].shape[1] == 171
+    assert np.sum(binaries[0]) == 0
+
+
+def test_logistics():
+    dataset = fetch_fs_peptide()
+    trajectories = dataset["trajectories"]
+    logisticcontactfeaturizer = LogisticContactFeaturizer()
+    logistics = logisticcontactfeaturizer.transform([trajectories[0]])
+
+    assert logistics[0].shape[1] == 171
+    assert np.amax(logistics[0]) < 1.0
+    assert np.amin(logistics[0]) > 0.0
+
+
+def test_distance_to_logistic():
+    dataset = fetch_fs_peptide()
+    trajectories = dataset["trajectories"]
+    steepness = np.absolute(10*np.random.randn())
+    center = np.absolute(np.random.randn())
+    contactfeaturizer = ContactFeaturizer()
+    contacts = contactfeaturizer.transform([trajectories[0]])
+    logisticcontactfeaturizer = LogisticContactFeaturizer(center=center, steepness=steepness)
+    logistics = logisticcontactfeaturizer.transform([trajectories[0]])
+
+    for n in range(0,10):
+        i = np.random.randint(0, contacts[0].shape[0] - 1)
+        j = np.random.randint(0, contacts[0].shape[1] - 1)
+    
+        x = contacts[0][i][j]
+        y = logistics[0][i][j]
+
+        if(x > center):
+            assert y < 0.5
+        if(x < center):
+            assert y > 0.5
+        n = n + 1
+
+
+def test_binary_to_logistics():
+    dataset = fetch_fs_peptide()
+    trajectories = dataset["trajectories"]
+    steepness = np.absolute(10*np.random.randn())
+    center = np.absolute(np.random.randn())
+    binarycontactfeaturizer = BinaryContactFeaturizer(cutoff=center)
+    binaries = binarycontactfeaturizer.transform([trajectories[0]])
+    logisticcontactfeaturizer = LogisticContactFeaturizer(center=center, steepness=steepness)
+    logistics = logisticcontactfeaturizer.transform([trajectories[0]])
+
+    # This checks that no distances that are larger than the center are logistically
+    # transformed such that they are less than 1/2
+    np.testing.assert_array_almost_equal(binaries[0], logistics[0] >  0.5 )
+
+


### PR DESCRIPTION
 - [x] Implement feature / fix bug
 - [x] Add tests
 - [x] Update changelog

Attempts to address #790 although not in a memory-saving way.

Simple code to incorporate mapping contacts to 1/0 if they are under/over a certain cutoff. They are temporarily cast as floats... the code is:
`distances = (distances < self.binary_cutoff).astype(float)`

Obviously can change the type as we want.

Also, I couldn't find in the [docs](http://mdtraj.org/latest/api/generated/mdtraj.compute_contacts.htmll) what the distances units are.