### PR TITLE
Make `short_version` shorter than `version`

### DIFF
--- a/basesetup.py
+++ b/basesetup.py
@@ -256,37 +256,37 @@ def git_version():
     return GIT_REVISION
 
 
-def write_version_py(VERSION, ISRELEASED, filename='MDTraj/version.py'):
+def write_version_py(version, isreleased, filename):
     cnt = """
-# THIS FILE IS GENERATED FROM MDTRAJ SETUP.PY
-short_version = '%(version)s'
-version = '%(version)s'
-full_version = '%(full_version)s'
-git_revision = '%(git_revision)s'
-release = %(isrelease)s
-
-if not release:
-    version = full_version
+# This file is generated in setup.py at build time.
+version = '{version}'
+short_version = '{short_version}'
+full_version = '{full_version}'
+git_revision = '{git_revision}'
+release = {release}
 """
-    # Adding the git rev number needs to be done inside write_version_py(),
-    # otherwise the import of numpy.version messes up the build under Python 3.
-    FULLVERSION = VERSION
+    # git_revision
     if os.path.exists('.git'):
-        GIT_REVISION = git_version()
+        git_revision = git_version()
     else:
-        GIT_REVISION = 'Unknown'
+        git_revision = 'Unknown'
 
-    if not ISRELEASED:
-        FULLVERSION += '.dev-' + GIT_REVISION[:7]
+    # short_version, full_version
+    if isreleased:
+        full_version = version
+        short_version = version
+    else:
+        full_version = ("{version}+{git_revision}"
+                        .format(version=version, git_revision=git_revision))
+        short_version = version
 
-    a = open(filename, 'w')
-    try:
-        a.write(cnt % {'version': VERSION,
-                       'full_version': FULLVERSION,
-                       'git_revision': GIT_REVISION,
-                       'isrelease': str(ISRELEASED)})
-    finally:
-        a.close()
+    with open(filename, 'w') as f:
+        f.write(cnt.format(version=version,
+                           short_version=short_version,
+                           full_version=full_version,
+                           git_revision=git_revision,
+                           release=isreleased))
+
 
 
 class StaticLibrary(Extension):

--- a/basesetup.py
+++ b/basesetup.py
@@ -272,13 +272,12 @@ release = {release}
         git_revision = 'Unknown'
 
     # short_version, full_version
+    short_version = ".".join(version.split(".")[:2])
     if isreleased:
         full_version = version
-        short_version = version
     else:
         full_version = ("{version}+{git_revision}"
                         .format(version=version, git_revision=git_revision))
-        short_version = version
 
     with open(filename, 'w') as f:
         f.write(cnt.format(version=version,

--- a/devtools/travis-ci/set_doc_version.py
+++ b/devtools/travis-ci/set_doc_version.py
@@ -3,7 +3,7 @@ import shutil
 from msmbuilder import version
 
 if version.release:
-    docversion = version.short_version
+    docversion = version.version
 else:
     docversion = 'development'
 

--- a/devtools/travis-ci/update_versions_json.py
+++ b/devtools/travis-ci/update_versions_json.py
@@ -19,10 +19,11 @@ for i in range(len(versions)):
     versions[i]['latest'] = False
 
 versions.append({
-    'version': version.short_version,
+    'version': version.version,
     'display': version.short_version,
-    'url': "{base}/{version}".format(base=URL, version=version.short_version),
-    'latest': True})
+    'url': "{base}/{version}".format(base=URL, version=version.version),
+    'latest': True,
+})
 
 with open("docs/_deploy/versions.json", 'w') as versionf:
     json.dump(versions, versionf, indent=2)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ This is the current development version of MSMBuilder
 API Changes
 ~~~~~~~~~~~
 
+- ``version.short_version`` is now 3.y instead of 3.y.z (#829).
 
 New Features
 ~~~~~~~~~~~~


### PR DESCRIPTION
- port `basesetup.py` changes from mdtraj
- change it so `short_version` takes the first two dotted things e.g. 3.6 not 3.6.0