### PR TITLE
No NaNs in commute mapping option for tICA

### DIFF
--- a/msmbuilder/decomposition/tica.py
+++ b/msmbuilder/decomposition/tica.py
@@ -340,11 +340,15 @@ class tICA(BaseEstimator, TransformerMixin):
                 # reference implementation in pyemma
                 #(markovmodel/PyEMMA#963)
                 # dampening smaller timescales based recommendtion of  [7]
+                #
+                # some timescales are NaNs and regularized timescales will 
+                # be negative when they are less than the lag time; all these
+                # are set to zero using nan_to_num before returning
                 regularized_timescales = 0.5 * self.timescales_ *\
                                          np.tanh( np.pi *((self.timescales_ - self.lag_time)
                                                           /self.lag_time) + 1)
-                regularized_timescales[regularized_timescales < 0] = 0.
                 X_transformed *= np.sqrt(regularized_timescales / 2)
+                X_transformed = np.nan_to_num(X_transformed)
             sequences_new.append(X_transformed)
 
         return sequences_new

--- a/msmbuilder/decomposition/tica.py
+++ b/msmbuilder/decomposition/tica.py
@@ -1,6 +1,6 @@
 # Author: Christian Schwantes <schwancr@gmail.com>
 # Contributors: Robert McGibbon <rmcgibbo@gmail.com>, Kyle A. Beauchamp  <kyleabeauchamp@gmail.com>,
-# Muneeb Sultan <msultan@stanford.edu>
+# Muneeb Sultan <msultan@stanford.edu>, Brooke Husic <brookehusic@gmail.com>
 # Copyright (c) 2014, Stanford University
 # All rights reserved.
 
@@ -343,6 +343,7 @@ class tICA(BaseEstimator, TransformerMixin):
                 regularized_timescales = 0.5 * self.timescales_ *\
                                          np.tanh( np.pi *((self.timescales_ - self.lag_time)
                                                           /self.lag_time) + 1)
+                regularized_timescales[regularized_timescales < 0] = 0.
                 X_transformed *= np.sqrt(regularized_timescales / 2)
             sequences_new.append(X_transformed)
 

--- a/msmbuilder/tests/test_decomposition.py
+++ b/msmbuilder/tests/test_decomposition.py
@@ -122,7 +122,7 @@ def test_tica_commute_mapping():
                              np.tanh( np.pi *((tica2.timescales_ - tica2.lag_time)
                                               /tica2.lag_time) + 1)
 
-    assert eq(y2, y1 * np.sqrt(regularized_timescales/2))
+    assert eq(y2, np.nan_to_num(y1 * np.sqrt(regularized_timescales/2)))
 
 def test_pca_vs_sklearn():
     # Compare msmbuilder.pca with sklearn.decomposition


### PR DESCRIPTION
 - [x] Implement feature / fix bug
 - [ ] Add tests
 - [ ] Update changelog

I came across this bug because `MiniBatchKMeans` was not working when I was using `tICA` with `commute_mapping=True`.

The commute mapping coefficients are a function of timescales, which have some NaNs at the small ones (maybe a deeper bug?). Also, when the timescale is less than the lag time, the commute mapping formulation involves taking the square root of a negative number, which also returns a NaN. Definitely doesn't make sense to do an absolute value here.

Instead, I have mapped NaNs from both these sources to zero using `np.nan_to_num.` Kmeans works now. I have talked to @cxhernandez about this. @msultan, @mpharrigan let me know what you think about this.