### PR TITLE
Errorbars for transition matrix

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,8 +12,8 @@ API Changes
 New Features
 ~~~~~~~~~~~~
 - Added functions to compute error bars for transition probabilities to account for
-finite sampling, and sample transition matrices from these error distributions (i.e.
-bootstrapping). Located in msmbuilder.msm.validation.transmat_errorbar.
+  finite sampling, and sample transition matrices from these error distributions (i.e.
+  bootstrapping). Located in ```msmbuilder.msm.validation.transmat_errorbar```.
 
 Improvements
 ~~~~~~~~~~~~

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,9 @@ API Changes
 
 New Features
 ~~~~~~~~~~~~
+- Added functions to compute error bars for transition probabilities to account for
+finite sampling, and sample transition matrices from these error distributions (i.e.
+bootstrapping). Located in msmbuilder.msm.validation.transmat_errorbar.
 
 Improvements
 ~~~~~~~~~~~~

--- a/msmbuilder/msm/validation/transmat_errorbar.py
+++ b/msmbuilder/msm/validation/transmat_errorbar.py
@@ -1,0 +1,52 @@
+import numpy as np
+
+
+def create_perturb_params(countsmat):
+    '''
+    Computes transition probabilities and standard errors of the transition probabilities due to 
+    finite sampling using the MSM counts matrix. First, the transition probabilities are computed 
+    by dividing the each element c_ij by the row-sumemd counts of row i. THe standard errors are then
+    computed by first computing the standard deviation of the transition probability, treating each count 
+    as a Bernoulli process with p = t_ij (std = (t_ij - t_ij ^2)^0.5). This is then divided by the 
+    square root of the row-summed counts of row i to obtain the standard error.
+    
+    Parameters:
+    ----------
+    countsmat: np.ndarray
+        The msm counts matrix
+
+    Returns:
+    -----------
+    transmat, np.ndarray:
+        The MSM transition matrix
+    scale, np.ndarray:
+        The matrix of standard errors for each transition probability
+    '''
+    norm = np.sum(countsmat, axis=1)
+    transmat = (countsmat.transpose() / norm).transpose()
+    counts = (np.ones((len(transmat), len(transmat))) * norm).transpose()
+    scale = ((transmat - transmat ** 2) ** 0.5 / counts ** 0.5) + 10 ** -15
+    return transmat, scale
+
+
+def perturb_tmat(transmat, scale):
+    '''
+    Perturbs each nonzero entry in the MSM transition matrix by treating it as a Gaussian random variable
+    with mean t_ij and standard deviation equal to the standard error computed using "create_perturb_params".
+    Returns a sampled transition matrix that takes into consideration errors due to finite sampling
+    (useful for boostrapping, etc.)
+
+    Parameters:
+    ----------
+    transmat: np.ndarray:
+        The transition matrix, whose elements serve as the means of the Gaussian random variables
+    scale: np.ndarray:
+        The matrix of standard errors. For transition probability t_ij, this is assumed to be the standard 
+        error of the mean of a binomial distribution with p = transition probability and number of observations 
+        equal to the summed counts in row i.
+
+    '''
+    output = np.vectorize(np.random.normal)(transmat, scale)
+    output[np.where(output < 0)] = 0
+    return (output.transpose() / np.sum(output, axis=1)).transpose()
+

--- a/msmbuilder/tests/test_transmat_errorbar.py
+++ b/msmbuilder/tests/test_transmat_errorbar.py
@@ -1,11 +1,11 @@
-from msmbuilder.tpt import mfpt
+from msmbuilder.msm.validation.transmat_errorbar import *
 import numpy as np
 
 
 def test_create_perturb_params():
     # Test with a 10x10 counts matrix, with all entries in the counts set to 100
     countsmat = 100 * np.ones((10,10))
-    params = mfpt.create_perturb_params(countsmat)
+    params = create_perturb_params(countsmat)
     # Check dimensions of outputs are equal to those of inputs
     for param in params:
         assert np.shape(param) == np.shape(countsmat) 
@@ -14,14 +14,14 @@ def test_create_perturb_params():
 def test_perturb_tmat():
     # The transition matrix is perturbed under the CLT approximation, which is only valid for well-sampled data w.r.t. transition probability (tprob >> 1 / row-summed counts)
     countsmat = 100 * np.ones((10,10)) # 10-state MSM, 1000 counts per state, 100 transition events between states, no zero entries
-    params = mfpt.create_perturb_params(countsmat)
-    new_transmat = (mfpt.perturb_tmat(params[0], params[1]))
+    params = create_perturb_params(countsmat)
+    new_transmat = (perturb_tmat(params[0], params[1]))
     # All transition probabilities are by design nonzero, so there should be no nonzero entries after the perturbation
     assert len(np.where(new_transmat == 0)[0]) == 0
     # Now let's assume you have a poorly sampled dataset where all elements in the counts matrix is 1
     countsmat = np.ones((10,10))
-    params = mfpt.create_perturb_params(countsmat)
-    new_transmat = (mfpt.perturb_tmat(params[0], params[1]))
+    params = create_perturb_params(countsmat)
+    new_transmat = (perturb_tmat(params[0], params[1]))
     # Your perturbed transition matrix will have several negative values (set automatically to 0), indicating this method probably isn't appropriate for your dataset
     # (This will also cause your distribution of MFPTs to have very obvious outliers to an otherwise approximately Gaussian distribution due to the artificial zeros in the transition matrix)
     assert len(np.where(new_transmat == 0)[0] > 0)

--- a/msmbuilder/tpt/mfpt.py
+++ b/msmbuilder/tpt/mfpt.py
@@ -23,46 +23,9 @@ import scipy
 from mdtraj.utils.six.moves import xrange
 import copy
 from msmbuilder.msm.core import _solve_msm_eigensystem
+from msmbuilder.msm.validation.transmat_errorbar import *
 
 __all__ = ['mfpts']
-
-
-def create_perturb_params(countsmat):
-    '''
-    Helper function for computing mfpts when "errors" argument is passed. 
-    Generates the means and standard deviations of the Gaussian random variables
-    for each transition probability that will be sampled from during the error calculation.
-    
-    Parameters:
-    ----------
-    countsmat: np.ndarray
-        The msm counts matrix
-    '''
-    norm = np.sum(countsmat, axis=1)
-    transmat = (countsmat.transpose() / norm).transpose()
-    counts = (np.ones((len(transmat), len(transmat))) * norm).transpose()
-    scale = ((transmat - transmat ** 2) ** 0.5 / counts ** 0.5) + 10 ** -15
-    return (transmat, scale)
-
-
-def perturb_tmat(loc, scale):
-    '''
-    Helper function for computing mfpts when "errors" argument is passed.
-    Perturbs each nonzero transition probability by treating it as a Gaussian random variable
-    and sampling from it once.
-    
-    Parameters:
-    ----------
-    loc: np.ndarray:
-        The transition matrix, whose elements serve as the means of the Gaussian random variables
-    scale: np.ndarray:
-        The matrix of standard deviations of the Gaussians. For transition probability (i,j), this is 
-        assumed to be the standard error of the mean of a binomial distribution with p = transition probability 
-        and number of observations equal to the summed counts in row i.
-    '''
-    output = np.vectorize(np.random.normal)(loc, scale)
-    output[np.where(output < 0)] = 0
-    return (output.transpose() / np.sum(output, axis=1)).transpose()
 
 
 def mfpts(msm, sinks=None, lag_time=1., errors=False, n_samples=100):


### PR DESCRIPTION
 - [x] Implement feature / fix bug
 - [x] Add tests
 - [x] Update changelog

Added functions to compute error bars for transition matrices and generate new transition matrices by sampling from these error distributions (i.e. bootstrapping) in msmbuilder.msm.validation.transmat_errorbar. 

Test is called test_transmat_errorbar.py