### PR TITLE
fixed bug in example datasets init

### DIFF
--- a/msmbuilder/example_datasets/__init__.py
+++ b/msmbuilder/example_datasets/__init__.py
@@ -24,6 +24,6 @@ __all__ = [
     'FsPeptide',
     'DoubleWell',
     'QuadWell',
-    'Muller',
+    'MullerPotential',
     'load_muller',
 ]


### PR DESCRIPTION
 - [x] Implement feature / fix bug
 - [ ] Add tests
 - [ ] Update changelog

fixed the following error

```
>>> from msmbuilder.example_datasets import *
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'module' object has no attribute 'Muller'
```