### PR TITLE
Correct tica warning

### DIFF
--- a/msmbuilder/decomposition/tica.py
+++ b/msmbuilder/decomposition/tica.py
@@ -402,7 +402,7 @@ class tICA(BaseEstimator, TransformerMixin):
         X = np.asarray(array2d(X), dtype=np.float64)
 
         if X.shape[1] > X.shape[0]:
-            warnings.warn("The number of features (%d) is greater than the length of the data (%d). The covariance matrix is not guaranteed to be positive definite." % (X.shape[0], X.shape[1]))
+            warnings.warn("The number of features (%d) is greater than the length of the data (%d). The covariance matrix is not guaranteed to be positive definite." % (X.shape[1], X.shape[0]))
 
         self._initialize(X.shape[1])
 


### PR DESCRIPTION
Fix confusing ~error~ warning message. Currently it gives a message like:

```
The number of features (500) is greater than the length of the data (2172)...
```
When the number of features is 2172 and the length of the data is 500.

 - [x] Implement feature / fix bug
 - [ ] Add tests
 - [ ] Update changelog

[Describe changes here]
