### PR TITLE
Change to FeatureSelector 'which_feat' setter. 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,7 @@ New Features
 
 Improvements
 ~~~~~~~~~~~~
+- ```FeatureSelector``` is now compatible with Tree-structure Parzen Estimator method in Osprey
 
 
 v3.8 (April 26, 2017)

--- a/msmbuilder/feature_selection/featureselector.py
+++ b/msmbuilder/feature_selection/featureselector.py
@@ -45,7 +45,6 @@ class FeatureSelector(Featurizer):
     def __init__(self, features, which_feat=None):
         self.features = OrderedDict(features)
         self.feat_list = list(self.features)
-
         which_feat = which_feat if which_feat else self.feat_list[:]
         self.which_feat = which_feat
 
@@ -66,9 +65,6 @@ class FeatureSelector(Featurizer):
             to the `i`th snapshot of the input trajectory.
         """
         print(self.which_feat, type(self.which_feat))
-
-        for feat in self.which_feat:
-            print(feat, type(feat))
         return np.concatenate([self.features[feat].partial_transform(traj)
                                for feat in self.which_feat], axis=1)
 

--- a/msmbuilder/feature_selection/featureselector.py
+++ b/msmbuilder/feature_selection/featureselector.py
@@ -4,7 +4,7 @@
 # All rights reserved.
 import numpy as np
 from collections import OrderedDict
-
+from six import string_types
 from ..featurizer import Featurizer
 
 
@@ -34,18 +34,19 @@ class FeatureSelector(Featurizer):
 
     @which_feat.setter
     def which_feat(self, value):
-        if not isinstance(value, list):
+        if isinstance(value, string_types):
             value = [value]
+        elif isinstance(value, dict):
+            raise TypeError('Not a valid feature list')
         elif not all([feat in self.feat_list for feat in value]):
             raise ValueError('Not a valid feature')
-        self._which_feat = value
+        self._which_feat = list(value)
 
     def __init__(self, features, which_feat=None):
         self.features = OrderedDict(features)
         self.feat_list = list(self.features)
 
         which_feat = which_feat if which_feat else self.feat_list[:]
-
         self.which_feat = which_feat
 
     def partial_transform(self, traj):
@@ -64,6 +65,10 @@ class FeatureSelector(Featurizer):
             vector is computed by applying the featurization function
             to the `i`th snapshot of the input trajectory.
         """
+        print(self.which_feat, type(self.which_feat))
+
+        for feat in self.which_feat:
+            print(feat, type(feat))
         return np.concatenate([self.features[feat].partial_transform(traj)
                                for feat in self.which_feat], axis=1)
 

--- a/msmbuilder/feature_selection/featureselector.py
+++ b/msmbuilder/feature_selection/featureselector.py
@@ -64,7 +64,6 @@ class FeatureSelector(Featurizer):
             vector is computed by applying the featurization function
             to the `i`th snapshot of the input trajectory.
         """
-        print(self.which_feat, type(self.which_feat))
         return np.concatenate([self.features[feat].partial_transform(traj)
                                for feat in self.which_feat], axis=1)
 

--- a/msmbuilder/tests/test_feature_selection.py
+++ b/msmbuilder/tests/test_feature_selection.py
@@ -51,3 +51,26 @@ def test_variancethreshold_vs_sklearn():
     z_ref1 = vtr.fit_transform(y)
 
     np.testing.assert_array_almost_equal(z_ref1, z1)
+
+def test_which_feat_types():
+    trajectories = AlanineDipeptide().get_cached().trajectories
+    fs = FeatureSelector(FEATS, which_feat=('phi', 'psi'))
+    assert fs.which_feat == ['phi', 'psi']
+
+    fs = FeatureSelector(FEATS, which_feat=set(('phi', 'psi')))
+    assert fs.which_feat == ['phi', 'psi'] or fs.which_feat == ['psi', 'phi']
+
+    try:
+        fs = FeatureSelector(FEATS, which_feat={'phi':'psi'})
+        assert False
+    except TypeError:
+        pass
+
+    try:
+        fs = FeatureSelector(FEATS, which_feat=['phiii'])
+        assert False
+    except ValueError:
+        pass
+
+
+test_which_feat_types()

--- a/msmbuilder/tests/test_feature_selection.py
+++ b/msmbuilder/tests/test_feature_selection.py
@@ -53,7 +53,7 @@ def test_variancethreshold_vs_sklearn():
     np.testing.assert_array_almost_equal(z_ref1, z1)
 
 def test_which_feat_types():
-    trajectories = AlanineDipeptide().get_cached().trajectories
+    # trajectories = AlanineDipeptide().get_cached().trajectories
     fs = FeatureSelector(FEATS, which_feat=('phi', 'psi'))
     assert fs.which_feat == ['phi', 'psi']
 
@@ -73,4 +73,3 @@ def test_which_feat_types():
         pass
 
 
-test_which_feat_types()


### PR DESCRIPTION
 - [x] Implement feature / fix bug
 - [x] Add tests
 - [x] Update changelog

`FeatureSelector` setter for `which_feat` previously cast all non-list variables to a list. 
```
if not list:
    value = [value]
```
This was causing `KeyError`'s with the  Tree-based Parzen Estimator method in Osprey as it passes tuples (seemingly impossible to change) to the `which_feat` variable. e.g.
```
which_feat = ('phi', 'psi')
```
got converted by the setter to:
```
which_feat = [('phi', 'psi')]
```
instead of:
```
which_feat = ['phi', 'psi']
```

This PR now fixes that by checking for string variable separately and casts everything else as a list: 
```
if string:
    value = [value]
if dictionary:
   TypeError
if value not in feature_list:
    TypeError
else:
     value = list(value)
```
