### PR TITLE
Fixed error in ligand contact CA featurizer

### DIFF
--- a/msmbuilder/featurizer/multichain.py
+++ b/msmbuilder/featurizer/multichain.py
@@ -170,7 +170,7 @@ class LigandContactFeaturizer(LigandFeaturizer):
 
     def _get_contact_pairs(self, contacts):
         if self.scheme=='ca':
-            if not any(a for a in self.reference_frame.top.chain(ligand_chain).atoms
+            if not any(a for a in self.reference_frame.top.chain(self.ligand_chain).atoms
                        if a.name.lower() == 'ca'):
                 raise ValueError("Bad scheme: the ligand has no alpha carbons")
 


### PR DESCRIPTION
 - [x] Implement feature / fix bug
 - [x] Add tests

Just a tiny typo that prevented ligand contact featurizer scheme="ca" from running. I made a test that catches it but it required a new fake trajectory with only one c-alpha per residue.

Bigger picture, the single-atom 'ca' scheme of ligand contact featurizing should probably support any atom name in the ligand rather than strictly 'ca'. Until then, renaming an atom in the ligand topology is pretty painless.