### PR TITLE
Add a maximum number of iterations in prinz mle

### DIFF
--- a/msmbuilder/decomposition/ktica.py
+++ b/msmbuilder/decomposition/ktica.py
@@ -175,9 +175,7 @@ class KernelTICA(tICA):
         # regularization parameters?
         m2 = self.__class__(shrinkage=self.shrinkage, n_components=self.n_components, lag_time=self.lag_time,
                             landmarks=self.landmarks, kernel_params=self.kernel_params)
-        for X in sequences:
-            m2.partial_fit(X)
-
+        m2.fit(sequences)
         numerator = V.T.dot(m2.offset_correlation_).dot(V)
         denominator = V.T.dot(m2.covariance_).dot(V)
 

--- a/msmbuilder/decomposition/ktica.py
+++ b/msmbuilder/decomposition/ktica.py
@@ -126,10 +126,12 @@ class KernelTICA(tICA):
                                   'coef0': self.coef0,
                                   'random_state': self.random_state
                                   }
+        self._nystroem = None
         super(KernelTICA, self).__init__(n_components=n_components,
                                          lag_time=lag_time,
                                          shrinkage=shrinkage,
                                          kinetic_mapping=kinetic_mapping)
+
 
     def _gen_landmarks(self, sequences):
         X = []
@@ -140,6 +142,50 @@ class KernelTICA(tICA):
             X.append(seq[np.unique((u, v))])
 
         return np.concatenate(X, axis=0)
+
+    def score(self, sequences, y=None):
+        """Score the model on new data using the generalized matrix Rayleigh quotient
+
+        Parameters
+        ----------
+        sequences : list of array, each of shape (n_samples_i, n_features)
+            Test data. A list of sequences in afeature space, each of which is a 2D
+            array of possibily different lengths, but the same number of features.
+
+        Returns
+        -------
+        gmrq : float
+            Generalized matrix Rayleigh quotient. This number indicates how
+            well the top ``n_timescales+1`` eigenvectors of this tICA model perform
+            as slowly decorrelating collective variables for the new data in
+            ``sequences``.
+
+        References
+        ----------
+        .. [1] McGibbon, R. T. and V. S. Pande, "Variational cross-validation
+           of slow dynamical modes in molecular kinetics" J. Chem. Phys. 142,
+           124105 (2015)
+        """
+
+        assert self._initialized
+        V = self.eigenvectors_
+
+        # Note: How do we deal with regularization parameters like gamma
+        # here? I'm not sure. Should C and S be estimated using self's
+        # regularization parameters?
+        m2 = self.__class__(shrinkage=self.shrinkage, n_components=self.n_components, lag_time=self.lag_time,
+                            landmarks=self.landmarks, kernel_params=self.kernel_params)
+        for X in sequences:
+            m2.partial_fit(X)
+
+        numerator = V.T.dot(m2.offset_correlation_).dot(V)
+        denominator = V.T.dot(m2.covariance_).dot(V)
+
+        try:
+            trace = np.trace(numerator.dot(np.linalg.inv(denominator)))
+        except np.linalg.LinAlgError:
+            trace = np.nan
+        return trace
 
     def fit(self, sequences, y=None):
         if self.landmarks is None:

--- a/msmbuilder/msm/_markovstatemodel.pyx
+++ b/msmbuilder/msm/_markovstatemodel.pyx
@@ -47,7 +47,7 @@ def _transmat_mle_prinz(double[:, ::1] C, double tol=1e-10):
     cdef double[::1] pi = np.zeros(n_states)
     cdef int n_iter
 
-    n_iter = transmat_mle_prinz(&C[0,0], n_states, tol, &T[0,0], &pi[0]);
+    n_iter = transmat_mle_prinz(&C[0,0], n_states, tol, &T[0,0], &pi[0])
     if n_iter < 0:
         # diagnose the error
         msg = ' Error code=%d' % n_iter
@@ -55,6 +55,8 @@ def _transmat_mle_prinz(double[:, ::1] C, double tol=1e-10):
             msg = 'Domain error. C must be positive.' + msg
         if np.any(np.sum(C, axis=1) == 0):
             msg = 'Row-sums of C must be positive.' + msg
+        if n_iter == -3:
+            msg = 'Likelihood not converged.' + msg
         raise ValueError(msg)
 
     return np.array(T), np.array(pi)

--- a/msmbuilder/msm/src/transmat_mle_prinz.c
+++ b/msmbuilder/msm/src/transmat_mle_prinz.c
@@ -4,6 +4,8 @@
 #include <stdlib.h>
 #include "transmat_mle_prinz.h"
 
+#define MAX_ITER 10000
+
 /**
  * Compute a maximum likelihood reversible transition matrix, given
  * a set of directed transition counts.
@@ -154,6 +156,11 @@ int transmat_mle_prinz(const double* C, int n_states, double tol,
             // logl is a nan
             free(X); free(X_RS); free(C_RS);
             return -2;
+        }
+
+        if (iter > MAX_ITER){
+            free(X); free(X_RS); free(C_RS);
+            return -3;
         }
     }
 


### PR DESCRIPTION
For some reason, my mle estimation was not converging within tolerance which resulted in a seemingly infinite loop and you cant ctrl-C. This adds a limit to the number of iterations attempted. 

looks like this pr is also pulling in #1024 . i can rebase if necessary