### PR TITLE
I was getting a "chain_dict referenced before assignment" error here.

### DIFF
--- a/msmbuilder/featurizer/multichain.py
+++ b/msmbuilder/featurizer/multichain.py
@@ -69,8 +69,7 @@ class LigandFeaturizer(Featurizer):
 
 
     def _guess_chains(self, traj):
-        if self.protein_chain == 'auto' or self.ligand_chain == 'auto':
-            chain_dict = {}
+        chain_dict = {}
         for i in range(traj.top.n_chains):
             # each entry in the chain_dict is a list:
             # [number of atoms, has a CA, has <100 atoms]

--- a/msmbuilder/featurizer/multichain.py
+++ b/msmbuilder/featurizer/multichain.py
@@ -61,7 +61,8 @@ class LigandFeaturizer(Featurizer):
         if reference_frame.top.n_chains < 2:
             raise ValueError("Topology must have at least two chains")
 
-        self.contacts = self._guess_chains(self.reference_frame)
+        if self.protein_chain == 'auto' or self.ligand_chain == 'auto':
+            self._guess_chains(self.reference_frame)
         self.p_residue_offset = self._get_residue_offset(self.protein_chain)
         self.l_residue_offset = self._get_residue_offset(self.ligand_chain)
         self.p_atom_offset = self._get_atom_offset(self.protein_chain)
@@ -165,7 +166,7 @@ class LigandContactFeaturizer(LigandFeaturizer):
         self.scheme = scheme
         self.binding_pocket = binding_pocket
 
-        self.contacts = self._get_contact_pairs(contacts)
+        self.contacts = self._get_contact_pairs(self.contacts)
 
     def _get_contact_pairs(self, contacts):
         if self.scheme=='ca':


### PR DESCRIPTION
It's unclear to me if there was ever any reason for `chain_dict` to not
be always initialized at the start of this method. It doesn't seem to
be used anywhere else.

 - [x] Implement feature / fix bug
 - [ ] Add tests
 - [ ] Update changelog

[Describe changes here]
