### PR TITLE
fix from_msm method

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,6 +28,8 @@ Improvements
 ~~~~~~~~~~~~
 - ```FeatureSelector``` is now compatible with Tree-structure Parzen Estimator
   method in Osprey (gh-1018).
+- Fixed bug in ```from_msm``` method for ```PCCA``` and ```PCCAPlus``` which
+  now allows a ```PCCAPlus``` objective function to be specified (gh-1036).
 
 
 v3.8 (April 26, 2017)

--- a/msmbuilder/lumping/pcca.py
+++ b/msmbuilder/lumping/pcca.py
@@ -26,8 +26,12 @@ class PCCA(MarkovStateModel):
 
     """
 
-    def __init__(self, n_macrostates, pcca_tolerance=1e-5, **kwargs):
+    def __init__(self, n_macrostates, objective_function=None,
+                 pcca_tolerance=1e-5, **kwargs):
         self.n_macrostates = n_macrostates
+        self.objective_function = objective_function
+        if self.objective_function is not None:
+            raise AttributeError("PCCA does not use an objective function")
         self.pcca_tolerance = pcca_tolerance
         super(PCCA, self).__init__(**kwargs)
 
@@ -98,7 +102,7 @@ class PCCA(MarkovStateModel):
             raise ValueError
 
     @classmethod
-    def from_msm(cls, msm, n_macrostates):
+    def from_msm(cls, msm, n_macrostates, objective_function=None):
         """Create and fit lumped model from pre-existing MSM.
 
         Parameters
@@ -114,7 +118,8 @@ class PCCA(MarkovStateModel):
             The fit PCCA(+) object.
         """
         params = msm.get_params()
-        lumper = cls(n_macrostates, **params)
+        lumper = cls(n_macrostates=n_macrostates,
+                     objective_function=objective_function, **params)
 
         lumper.transmat_ = msm.transmat_
         lumper.populations_ = msm.populations_

--- a/msmbuilder/lumping/pcca_plus.py
+++ b/msmbuilder/lumping/pcca_plus.py
@@ -22,7 +22,7 @@ class PCCAPlus(PCCA):
         If False, skip the optimization of the transformation matrix.
         In general, minimization is recommended.
     objective_function: {'crisp_metastablility', 'metastability',
-                         'metastability'}
+                         'crispness'}
         Possible objective functions.  See objective for details.
     kwargs : optional
         Additional keyword arguments to be passed to MarkovStateModel.  See
@@ -99,6 +99,8 @@ class PCCAPlus(PCCA):
                 metastability=metastability,
                 crisp_metastability=crisp_metastability
         )
+        if objective_function is None:
+            objective_function = 'crisp_metastability'
         try:
             self._objective_function = obj_functions[objective_function]
         except KeyError:

--- a/msmbuilder/tests/test_lumping.py
+++ b/msmbuilder/tests/test_lumping.py
@@ -73,6 +73,14 @@ def test_from_msm():
     pccaplus = PCCAPlus.from_msm(msm, 2)
 
 
+def test_from_msm_2():
+    assignments, _ = _metastable_system()
+    msm = MarkovStateModel()
+    msm.fit(assignments)
+    pccaplus = PCCAPlus.from_msm(msm, 2, 'crispness')
+    assert pccaplus.objective_function == 'crispness'
+
+
 def test_ntimescales_1():
     # see issue #603
     trajs = [random.randint(0, 100, size=500) for _ in range(15)]


### PR DESCRIPTION
 - [x] Implement feature / fix bug
 - [x] Add tests
 - [x] Update changelog

The `from_msm` method for `PCCA` and `PCCAPlus` didn't allow the specification of a `PCCAPlus` objective function and now it does. Will deal with changelog after merging #1035.