### PR TITLE
Avoid 'gamma' in tICA constructor

### DIFF
--- a/examples/advanced/plot-tica-heatmap.ipynb
+++ b/examples/advanced/plot-tica-heatmap.ipynb
@@ -12,9 +12,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from __future__ import print_function\n",
@@ -32,9 +30,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "dataset = fetch_met_enkephalin()\n",
@@ -45,7 +41,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "collapsed": false
+    "collapsed": true
    },
    "outputs": [],
    "source": [
@@ -53,7 +49,7 @@
     "    transformed = pipeline.fit_transform(trajectories)\n",
     "    transformed = np.concatenate(transformed)\n",
     "\n",
-    "    print('Eiegenvaue sum', pipeline.named_steps['tica'].eigenvalues_.sum())\n",
+    "    print('Eiegenvalue sum', pipeline.named_steps['tica'].eigenvalues_.sum())\n",
     "\n",
     "    x = transformed[:, 0]\n",
     "    y = transformed[:, 1]\n",
@@ -70,9 +66,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Get all pairs of non-hydrogen atoms\n",
@@ -83,7 +77,7 @@
     " \n",
     "pipeline1 = Pipeline([\n",
     "    ('feat', AtomPairsFeaturizer(heavy_pairs)),\n",
-    "    ('tica', tICA(gamma=0, n_components=2)),\n",
+    "    ('tica', tICA(n_components=2)),\n",
     "])\n",
     "\n",
     "fit_and_plot(pipeline1, dataset.trajectories)"
@@ -100,6 +94,7 @@
   }
  ],
  "metadata": {
+  "hide_input": false,
   "kernelspec": {
    "display_name": "Python 3",
    "language": "python",
@@ -115,9 +110,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.3"
+   "version": "3.6.0"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }


### PR DESCRIPTION
The notebook was giving an error because of the "gamma" argument in the constructor of the tICA object.