### PR TITLE
Fix sample_dimension to work with scheme='edge'

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,6 +28,7 @@ Improvements
 ~~~~~~~~~~~~
 - ```FeatureSelector``` is now compatible with Tree-structure Parzen Estimator
   method in Osprey (gh-1018).
+- ```sample_dimenstion``` with ```scheme='edge'``` now works properly.
 
 
 v3.8 (April 26, 2017)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,7 +28,7 @@ Improvements
 ~~~~~~~~~~~~
 - ```FeatureSelector``` is now compatible with Tree-structure Parzen Estimator
   method in Osprey (gh-1018).
-- ```sample_dimenstion``` with ```scheme='edge'``` now works properly.
+- ```msmbuilder.io.sampling.sample_dimension``` with ```scheme='edge'``` now works properly. (#1043)
 
 
 v3.8 (April 26, 2017)

--- a/msmbuilder/io/sampling/sampling.py
+++ b/msmbuilder/io/sampling/sampling.py
@@ -49,6 +49,7 @@ def sample_dimension(trajs, dimension, n_frames, scheme="linear"):
         txx = np.sort(txx)
         spaced_points = np.hstack((txx[:_cut_point],
                                    txx[-_cut_point:]))
+        spaced_points = np.reshape(spaced_points, new_shape=(len(spaced_points), 1))
     else:
         raise ValueError("Scheme has be to one of linear, random or edge")
 

--- a/msmbuilder/io/sampling/sampling.py
+++ b/msmbuilder/io/sampling/sampling.py
@@ -49,7 +49,7 @@ def sample_dimension(trajs, dimension, n_frames, scheme="linear"):
         txx = np.sort(txx)
         spaced_points = np.hstack((txx[:_cut_point],
                                    txx[-_cut_point:]))
-        spaced_points = np.reshape(spaced_points, new_shape=(len(spaced_points), 1))
+        spaced_points = np.reshape(spaced_points, newshape=(len(spaced_points), 1))
     else:
         raise ValueError("Scheme has be to one of linear, random or edge")
 

--- a/msmbuilder/tests/test_sampling.py
+++ b/msmbuilder/tests/test_sampling.py
@@ -15,3 +15,15 @@ def test_sample_dimension():
     res2 = sample_dimension(tica_trajs, 1, 10, scheme="linear")
 
     assert len(res) == len(res2) == 10
+
+def test_sample_dimension_2():
+    np.random.seed(42)
+    X = np.random.randn(500, 5)
+    data = [X, X, X]
+
+    tica = tICA(n_components=2, lag_time=1).fit(data)
+    tica_trajs = {k: tica.partial_transform(v) for k, v in enumerate(data)}
+    res = sample_dimension(tica_trajs, 0, 10, scheme="random")
+    res2 = sample_dimension(tica_trajs, 1, 10, scheme="edge")
+
+    assert len(res) == len(res2) == 10


### PR DESCRIPTION
 - [x] Implement feature / fix bug
 - [x] Add tests
 - [x] Update changelog

Hi,

I was running into a `ValueError` when trying to use the 'edge' scheme in the `msmbuilder.io.sampling.sample_dimension` function.

This was the error (`ad.ttrajs`) is a dictionary of `np.arrays` coming from a tICA transformation:
```python
sample_dimension(ad.ttrajs, 0, 2, 'edge')
```
```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-191-10dea919ffc1> in <module>()
----> 1 sample_dimension(ad.ttrajs, 0, 2, 'edge')

<ipython-input-190-e60a27f800b8> in sample_dimension(trajs, dimension, n_frames, scheme)
     45     print(spaced_points.shape)
     46     tree = KDTree(trajs)
---> 47     dists, inds = tree.query(spaced_points)
     48     return [(fixed_indices[i], j) for i, j in inds]

~/miniconda3/lib/python3.6/site-packages/msmbuilder/utils/nearest.py in query(self, x, k, p, distance_upper_bound)
    122         (0.0034, array([  0, 410]))
    123         """
--> 124         cdists, cinds = self._kdtree.query(x, k, p, distance_upper_bound)
    125         return cdists, self._split_indices(cinds)
    126 

~/miniconda3/lib/python3.6/site-packages/scipy/spatial/kdtree.py in query(self, x, k, eps, p, distance_upper_bound)
    483         x = np.asarray(x)
    484         if np.shape(x)[-1] != self.m:
--> 485             raise ValueError("x must consist of vectors of length %d but has shape %s" % (self.m, np.shape(x)))
    486         if p < 1:
    487             raise ValueError("Only p-norms with 1<=p<=infinity permitted")

ValueError: x must consist of vectors of length 1 but has shape (2,)
```
and with the fix, the following is returned:
```
[(50, 148), (28, 82)]
```
I found it by noticing that `spaced_points.shape` was `(n_frames, 1)` both for the `linear` and `random` schemes, but `(n_frames,)` for `scheme=edge`.
I also added a new test which I think wouldn't have passed before. 

Let me know if you think this is how it should work now, I've checked with my trajectories and have verified that indeed the scheme is picking frames that are near the edges of the tIC. 

