### PR TITLE
Make it so that zippy_maker returns ordered unique lists.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -40,6 +40,8 @@ Improvements
 - Fixed bug in ```from_msm``` method for ```PCCA``` and ```PCCAPlus``` which
   now allows a ```PCCAPlus``` objective function to be specified (gh-1036).
 - ```msmbuilder.io.sampling.sample_dimension``` with ```scheme='edge'``` now works properly. (#1043)
+- Changed zippy_maker code so that ```Featurizer.describe_features``` will
+  return ordered unique lists to make reading and subselecting features easier.
 
 
 v3.8 (April 26, 2017)

--- a/msmbuilder/featurizer/featurizer.py
+++ b/msmbuilder/featurizer/featurizer.py
@@ -15,6 +15,7 @@ import numpy as np
 import sklearn.pipeline
 from scipy.stats import vonmises as vm
 from msmbuilder import libdistance
+from msmbuilder.utils import unique
 import itertools
 import inspect
 from sklearn.base import TransformerMixin
@@ -26,11 +27,11 @@ def zippy_maker(aind_tuples, top):
     resids = []
     resnames = []
     for ainds in aind_tuples:
-        resid = set(top.atom(ai).residue.index for ai in ainds)
+        resid = unique([top.atom(ai).residue.index for ai in ainds])
         resids += [list(resid)]
-        reseq = set(top.atom(ai).residue.resSeq for ai in ainds)
+        reseq = unique([top.atom(ai).residue.resSeq for ai in ainds])
         resseqs += [list(reseq)]
-        resname = set(top.atom(ai).residue.name for ai in ainds)
+        resname = unique([top.atom(ai).residue.name for ai in ainds])
         resnames += [list(resname)]
 
     return zip(aind_tuples, resseqs, resids, resnames)

--- a/msmbuilder/tests/test_convenience.py
+++ b/msmbuilder/tests/test_convenience.py
@@ -1,0 +1,7 @@
+
+from msmbuilder.utils import unique
+
+def test_unique():
+    assert unique([1,2,3,3,2,1]) == [1,2,3]
+    assert unique([3,3,2,2,1,1]) == [3,2,1]
+    assert unique([3,1,2,1,2,3]) == [3,1,2]

--- a/msmbuilder/utils/__init__.py
+++ b/msmbuilder/utils/__init__.py
@@ -8,3 +8,4 @@ from .validation import *
 from .compat import *
 from .nearest import KDTree
 from .divergence import *
+from .convenience import *

--- a/msmbuilder/utils/convenience.py
+++ b/msmbuilder/utils/convenience.py
@@ -1,0 +1,8 @@
+from __future__ import print_function, division, absolute_import
+
+def unique(seq):
+    '''Returns a list of unique items maintaining the order of the original.
+    '''
+    seen = set()
+    seen_add = seen.add
+    return [x for x in seq if not (x in seen or seen_add(x))]


### PR DESCRIPTION
Helps when reading the describe_features output and also
subselecting easier as well.

 - [x] Implement feature / fix bug
 - [x] Add tests
 - [x] Update changelog

Really simple but this has made my life a bit easier on a few occasions and thought I'd commit it. I added a test for the unique function but I can also add a test to be sure `describe_features` returns what was expected if we think that could be helpful (no direct test of that currently).