### PR TITLE
Add periodic option to contact featurizers

### DIFF
--- a/msmbuilder/featurizer/featurizer.py
+++ b/msmbuilder/featurizer/featurizer.py
@@ -1118,7 +1118,7 @@ class ContactFeaturizer(Featurizer):
         The value of beta to use for the soft_min distance option.
         Very large values might cause small contact distances to go to 0.
     periodic : bool, default=True
-        Computes distances using periodic boundary conditions.
+        If True, compute distances using periodic boundary conditions.
     """
 
     def __init__(self, contacts='all', scheme='closest-heavy', ignore_nonprotein=True,

--- a/msmbuilder/featurizer/featurizer.py
+++ b/msmbuilder/featurizer/featurizer.py
@@ -1117,10 +1117,12 @@ class ContactFeaturizer(Featurizer):
     soft_min_beta : float, default=20nm
         The value of beta to use for the soft_min distance option.
         Very large values might cause small contact distances to go to 0.
+    periodic : bool, default=True
+        Computes distances using periodic boundary conditions.
     """
 
     def __init__(self, contacts='all', scheme='closest-heavy', ignore_nonprotein=True,
-                 soft_min=False, soft_min_beta=20):
+                 soft_min=False, soft_min_beta=20, periodic=True):
         self.contacts = contacts
         self.scheme = scheme
         self.ignore_nonprotein = ignore_nonprotein
@@ -1129,6 +1131,7 @@ class ContactFeaturizer(Featurizer):
         if self.soft_min and not 'soft_min' in inspect.signature(md.compute_contacts).parameters:
             raise ValueError("Sorry but soft_min requires the latest version"
                              "of mdtraj")
+        self.periodic = periodic
 
     def _transform(self, distances):
         return distances
@@ -1158,10 +1161,12 @@ class ContactFeaturizer(Featurizer):
             distances, _ = md.compute_contacts(traj, self.contacts,
                                                self.scheme, self.ignore_nonprotein,
                                                soft_min=self.soft_min,
-                                               soft_min_beta=self.soft_min_beta)
+                                               soft_min_beta=self.soft_min_beta,
+                                               periodic=self.periodic)
         else:
             distances, _ = md.compute_contacts(traj, self.contacts,
-                                               self.scheme, self.ignore_nonprotein)
+                                               self.scheme, self.ignore_nonprotein,
+                                               periodic=self.periodic)
         return self._transform(distances)
 
 
@@ -1194,11 +1199,13 @@ class ContactFeaturizer(Featurizer):
                                                          self.scheme,
                                                          self.ignore_nonprotein,
                                                          soft_min=self.soft_min,
-                                                         soft_min_beta=self.soft_min_beta)
+                                                         soft_min_beta=self.soft_min_beta,
+                                                         periodic=self.periodic)
         else:
             distances, residue_indices = md.compute_contacts(traj[0], self.contacts,
                                                          self.scheme,
-                                                         self.ignore_nonprotein)
+                                                         self.ignore_nonprotein,
+                                                         periodic=self.periodic)
         top = traj.topology
 
         aind = []

--- a/msmbuilder/featurizer/multichain.py
+++ b/msmbuilder/featurizer/multichain.py
@@ -38,9 +38,7 @@ class LigandFeaturizer(Featurizer):
         single-frame conformation to get chain information; also defines
         the binding pocket if specified
     periodic : bool, default='True'
-        whether to compute minimum image distance, following periodic 
-        boundary conditions, or not.
-
+        If True, compute distances using periodic boundary conditions.
     Notes
     -----
     At the bare minimum, a featurizer must implement the `partial_transform(traj)`
@@ -157,18 +155,20 @@ class LigandContactFeaturizer(LigandFeaturizer):
         nanometer cutoff to define a binding pocket; if defined, only
         protein atoms within the threshold distance according to the
         topology file will be included
-
+    periodic : bool, default=True
+        If True, compute distances using periodic boundary conditions.
     """
 
     def __init__(self, protein_chain='auto', ligand_chain='auto',
                  reference_frame=None, contacts='all', 
-                 scheme='closest-heavy', binding_pocket='all'):
+                 scheme='closest-heavy', binding_pocket='all', periodic=True):
         super(LigandContactFeaturizer, self).__init__(
                     protein_chain=protein_chain, ligand_chain=ligand_chain,
                     reference_frame=reference_frame)
         self.contacts = contacts
         self.scheme = scheme
         self.binding_pocket = binding_pocket
+        self.periodic = periodic
 
         self.contacts = self._get_contact_pairs(self.contacts)
 

--- a/msmbuilder/featurizer/multichain.py
+++ b/msmbuilder/featurizer/multichain.py
@@ -37,6 +37,9 @@ class LigandFeaturizer(Featurizer):
     reference_frame : md.Trajectory, default=None
         single-frame conformation to get chain information; also defines
         the binding pocket if specified
+    periodic : bool, default='True'
+        whether to compute minimum image distance, following periodic 
+        boundary conditions, or not.
 
     Notes
     -----
@@ -47,10 +50,11 @@ class LigandFeaturizer(Featurizer):
 
 
     def __init__(self, protein_chain='auto', ligand_chain='auto',
-                 reference_frame=None):
+                 reference_frame=None, periodic=True):
         self.protein_chain = protein_chain
         self.ligand_chain = ligand_chain
         self.reference_frame = reference_frame
+        self.periodic = periodic
 
         if reference_frame is None:
             raise ValueError("Please specify a reference frame")
@@ -204,7 +208,7 @@ class LigandContactFeaturizer(LigandFeaturizer):
         if self.binding_pocket is not 'all':
             ref_distances, _ = md.compute_contacts(self.reference_frame, 
                                      self.residue_pairs, self.scheme,
-                                     ignore_nonprotein=False)
+                                     ignore_nonprotein=False, periodic = self.periodic)
             self.residue_pairs = self.residue_pairs[np.where(ref_distances<
                                      self.binding_pocket)[1]]
             if len(self.residue_pairs) == 0:
@@ -245,7 +249,8 @@ class LigandContactFeaturizer(LigandFeaturizer):
                           "the same as that of the reference frame," +
                           "which might give meaningless results.")
         distances, _ = md.compute_contacts(traj, self.contacts,
-                                        self.scheme, ignore_nonprotein=False)
+                                        self.scheme, ignore_nonprotein=False,
+                                        periodic = self.periodic)
         return self._transform(distances)
 
     def describe_features(self, traj):
@@ -273,7 +278,8 @@ class LigandContactFeaturizer(LigandFeaturizer):
         # fill in the atom indices using just the first frame
         distances, residue_indices = md.compute_contacts(traj[0],
                                         self.contacts, self.scheme,
-                                        ignore_nonprotein=False)
+                                        ignore_nonprotein=False,
+                                        periodic=self.periodic)
         top = traj.topology
 
         aind = []


### PR DESCRIPTION
 - [x] Implement feature / fix bug
 - [ ] Add tests
 - [ ] Update changelog

Added 'periodic' argument to ContactFeaturizer and multichain LigandContactFeaturizer to opt to calculate distances with or without the minimum image convention.  There are no current tests regarding the existing periodic options in GaussianSolventFeaturizer and AtomPairsFeaturizer, would be glad for feedback on tests to add.