### PR TITLE
Modified import of ParameterGrid for compatibility with sklearn 0.20 and below. 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -46,7 +46,7 @@ Improvements
 - Changed zippy_maker code so that ```Featurizer.describe_features``` will
   return ordered unique lists to make reading and subselecting features easier.
 - ``SASAFeaturizer`` now really supports the ``describe_features`` method (gh-913).
-
+- Made ``ParameterGrid`` import compatible with ``scikit-learn`` version 0.20 and below.
 
 v3.8 (April 26, 2017)
 ---------------------

--- a/msmbuilder/utils/param_sweep.py
+++ b/msmbuilder/utils/param_sweep.py
@@ -1,6 +1,6 @@
 from __future__ import print_function, division, absolute_import
 from sklearn import clone
-from sklearn.grid_search import ParameterGrid
+from sklearn.model_selection import ParameterGrid
 from sklearn.externals.joblib import Parallel, delayed
 
 __all__ = ['param_sweep']

--- a/msmbuilder/utils/param_sweep.py
+++ b/msmbuilder/utils/param_sweep.py
@@ -1,6 +1,10 @@
 from __future__ import print_function, division, absolute_import
 from sklearn import clone
-from sklearn.model_selection import ParameterGrid
+try:
+    from sklearn.model_selection import ParameterGrid
+except ImportError:
+    from sklearn.grid_search import ParameterGrid
+
 from sklearn.externals.joblib import Parallel, delayed
 
 __all__ = ['param_sweep']


### PR DESCRIPTION

 - [x] Implement feature / fix bug
 - [ ] Add tests
 - [x] Update changelog

for compatibility with scikit-learn 0.20 I changed `utils/param_sweep.py` imports from 

`from sklearn.grid_search import ParameterGrid`

to

```
try:
    from sklearn.model_selection import ParameterGrid
except ImportError:
    from sklearn.grid_search import ParameterGrid
```